### PR TITLE
Soften wrong-move sound and sort coaching feed by ply

### DIFF
--- a/ChessCoach/Services/SoundService.swift
+++ b/ChessCoach/Services/SoundService.swift
@@ -41,7 +41,8 @@ final class SoundService {
                Bundle.main.url(forResource: sound.rawValue, withExtension: "caf") {
                 if let player = try? AVAudioPlayer(contentsOf: url) {
                     player.prepareToPlay()
-                    player.volume = 0.5
+                    // Wrong-move sound is intentionally quieter to avoid being annoying
+                    player.volume = sound == .wrong ? 0.15 : 0.5
                     players[sound] = player
                 }
             }

--- a/ChessCoach/Views/Session/SessionView.swift
+++ b/ChessCoach/Views/Session/SessionView.swift
@@ -180,8 +180,8 @@ struct SessionView: View {
                     liveStatus
                         .id("live")
 
-                    // Feed entries (newest first) — tappable to replay board
-                    ForEach(viewModel.feedEntries) { entry in
+                    // Feed entries (newest first, sorted by ply) — tappable to replay board
+                    ForEach(viewModel.feedEntries.sorted { $0.whitePly > $1.whitePly }) { entry in
                         feedRow(entry)
                     }
                 }


### PR DESCRIPTION
## Summary
- **Fix #6**: Reduce wrong-move sound volume from 0.5 to 0.15 (70% quieter) so it's less annoying during practice sessions. The sound still plays but is much softer.
- **Fix #13**: Sort `SessionView` coaching feed entries by `whitePly` descending before display, preventing out-of-order entries when async coaching responses arrive non-sequentially. The `GamePlayView+CoachingFeed` already had this sort in place.

## Test plan
- [ ] Play a wrong move in a guided/unguided session and verify the sound is noticeably softer but still audible
- [ ] Play several moves in a session and verify feed entries always appear in correct move order
- [ ] Verify the coaching feed in GamePlayView (trainer mode) still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)