### PR TITLE
Phase 4b: Off-book coaching, opening indicator, free-tier fix

### DIFF
--- a/ChessCoach.xcodeproj/project.pbxproj
+++ b/ChessCoach.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		7F97EB110B25E2CF4417F577 /* BotAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFCAE5777C6BE579572202A0 /* BotAvatarView.swift */; };
 		803818021654390D75E31F42 /* FreeOpeningPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A1EF8E1BADDEBEBF771C2E /* FreeOpeningPickerView.swift */; };
 		883650AE7EAE693E5087F6D2 /* llama.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D28EFD69B9A9AC6E2DCD75B /* llama.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8BE37560F91B86A6846D7192 /* OpeningIndicatorBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC7551DFA272832EC2159E0 /* OpeningIndicatorBannerTests.swift */; };
 		8CE08A1FABED074CF7F2E648 /* CoachingValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341B1A08A7983B4F1184C6DE /* CoachingValidator.swift */; };
 		8E242137DD49CC9A1D211558 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FDC260D734D8B831132CF4 /* FeedbackService.swift */; };
 		8E75F54BDD3411D67906D1A8 /* CurriculumService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265BE80A3610E556D8016C1 /* CurriculumService.swift */; };
@@ -140,6 +141,7 @@
 		ABD380CAB30C6D3F85D6C21E /* d.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 1867A0DA1022B6A0D88542F6 /* d.tsv */; };
 		ACD22C78717532BF8901805C /* CardContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B4D2FF3E8F712FB78D1E0A /* CardContainer.swift */; };
 		ADA1C53F5D6201675DF55762 /* ImportedGameDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024801AB3D5AFACB32347F4B /* ImportedGameDetailView.swift */; };
+		AE9A032A685AA1908D390995 /* OpeningIndicatorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BBE51C943D8F454F73F1BC /* OpeningIndicatorBanner.swift */; };
 		AFD70421FEF05BA16D72675E /* GamePlayView+ReplayBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0EC57299D9EA7D6539DCEB /* GamePlayView+ReplayBar.swift */; };
 		B0C1DBEC59D44DEFF1B77568 /* LLMConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C770663D937BE38E72D9613 /* LLMConfig.swift */; };
 		B1A90672488F161FA789E763 /* english.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DA00C7F6D1D7DF09E5B556E /* english.json */; };
@@ -270,6 +272,7 @@
 		31501E26BAA6604484201596 /* french.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = french.json; sourceTree = "<group>"; };
 		316C3C4B6A21C5ECFB7412EB /* OffBookCoachingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffBookCoachingServiceTests.swift; sourceTree = "<group>"; };
 		3175B096AC5C4CC89EC1CCD5 /* ELOAssessmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ELOAssessmentView.swift; sourceTree = "<group>"; };
+		32BBE51C943D8F454F73F1BC /* OpeningIndicatorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningIndicatorBanner.swift; sourceTree = "<group>"; };
 		332F891136AFED8AAB292209 /* OpponentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpponentResponse.swift; sourceTree = "<group>"; };
 		336300F72FB21993A4A91474 /* GameAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameAnalysisService.swift; sourceTree = "<group>"; };
 		341B1A08A7983B4F1184C6DE /* CoachingValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachingValidator.swift; sourceTree = "<group>"; };
@@ -429,6 +432,7 @@
 		F7D0CD4928F8B4836EB000B9 /* CoachGuidance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachGuidance.swift; sourceTree = "<group>"; };
 		FA7CF3B22F5147835FC7DBEB /* MoveFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveFeedbackView.swift; sourceTree = "<group>"; };
 		FC292A6050005623D5DD1496 /* MultiArrowOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiArrowOverlay.swift; sourceTree = "<group>"; };
+		FDC7551DFA272832EC2159E0 /* OpeningIndicatorBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningIndicatorBannerTests.swift; sourceTree = "<group>"; };
 		FE4AA3F2F495DCEE68EC8C59 /* ConceptIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptIntroView.swift; sourceTree = "<group>"; };
 		FF0CC07054E86C382A99D579 /* sicilian.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = sicilian.json; sourceTree = "<group>"; };
 		FFFB3DE6F0EF145A730450D0 /* QuickReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickReviewView.swift; sourceTree = "<group>"; };
@@ -539,6 +543,7 @@
 			isa = PBXGroup;
 			children = (
 				2143B3E919308B6096193DB6 /* GameTopBar.swift */,
+				32BBE51C943D8F454F73F1BC /* OpeningIndicatorBanner.swift */,
 				961F8FE3E5223459C2589B33 /* PlayersBar.swift */,
 				24F00812A5CDD0A001B9E998 /* ReplayBar.swift */,
 			);
@@ -679,6 +684,14 @@
 			path = Subscription;
 			sourceTree = "<group>";
 		};
+		5C21ACFDC3D1A4B4F24E7D37 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				FDC7551DFA272832EC2159E0 /* OpeningIndicatorBannerTests.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		74F1A30766BC552284FEC95E /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -796,6 +809,7 @@
 				B8C29BA1613ECAC66CAEBEA6 /* ChessCoachTests.swift */,
 				770D8201EC0ED5937BD506C7 /* Models */,
 				B47587F877E79B7DC121AEDB /* Services */,
+				5C21ACFDC3D1A4B4F24E7D37 /* Views */,
 			);
 			path = ChessCoachTests;
 			sourceTree = "<group>";
@@ -1220,6 +1234,7 @@
 				153407464C23E1214B8097CA /* LLMServiceTests.swift in Sources */,
 				FF1C97579B3EFDE64118941E /* OffBookCoachingServiceTests.swift in Sources */,
 				9088B40A68C9CAA472A56AC1 /* OpeningDatabaseTests.swift in Sources */,
+				8BE37560F91B86A6846D7192 /* OpeningIndicatorBannerTests.swift in Sources */,
 				E8EB6F8BD6792748DF4BD638 /* OpeningTests.swift in Sources */,
 				9A02F7CA0B5E5DB2D7028B52 /* PersistenceMigrationTests.swift in Sources */,
 				E75180768E098D74D02DB633 /* SessionResultTests.swift in Sources */,
@@ -1323,6 +1338,7 @@
 				1B2B9B24A0F296310D363E74 /* OpeningDetailView.swift in Sources */,
 				90A48C0BDEB0AEEE44C88102 /* OpeningDetector.swift in Sources */,
 				EB5E0148A225AFF589BE912A /* OpeningFamiliarity.swift in Sources */,
+				AE9A032A685AA1908D390995 /* OpeningIndicatorBanner.swift in Sources */,
 				BB694D968E17549AC66FC86A /* OpeningPlan.swift in Sources */,
 				3178F5266616D59190419A32 /* OpeningPreviewBoard.swift in Sources */,
 				9D4FD434BB217352E32CC783 /* OpeningSettingsView.swift in Sources */,

--- a/ChessCoach.xcodeproj/project.pbxproj
+++ b/ChessCoach.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1453315DFD8DCD47720F1396 /* ruy-lopez.json in Resources */ = {isa = PBXBuildFile; fileRef = 66B78C9830B86C4B833EC635 /* ruy-lopez.json */; };
 		153407464C23E1214B8097CA /* LLMServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43293FAD4058537CD08C844 /* LLMServiceTests.swift */; };
 		1600D11F53255E67DB71C598 /* vienna.json in Resources */ = {isa = PBXBuildFile; fileRef = 2CD82359955074892F6D0D84 /* vienna.json */; };
+		183B67ABB65A4C2EC41B945D /* CoachingTierBadgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C137CFBA1FFE261F6FEBB1E /* CoachingTierBadgeTests.swift */; };
 		19C94F7D53A9777AFA4FB263 /* PuzzleModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1433100DC8C346D9659D68 /* PuzzleModeView.swift */; };
 		1A5406F5F565EF0BCA18C513 /* nimzo-indian.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CBAC99CDFF834C696E1736D /* nimzo-indian.json */; };
 		1B2B9B24A0F296310D363E74 /* OpeningDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B4A2582942F5C8B3786338 /* OpeningDetailView.swift */; };
@@ -79,6 +80,7 @@
 		52D6C103228BC322728622FB /* ChessKitEngine in Frameworks */ = {isa = PBXBuildFile; productRef = 111E24467C545F77B7F648BA /* ChessKitEngine */; };
 		5631F07DEDC0C264386395AE /* maia2_moves.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5AF349EACF6870397174001C /* maia2_moves.txt */; };
 		58BB6002CE1169095996ABB1 /* GamePlayViewModel+Trainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB5CFE7C0B8CD1D6F0D6540 /* GamePlayViewModel+Trainer.swift */; };
+		58DFC4A7DD236BD5C5432FB8 /* CoachingUpgradeCTA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6309E9D0A1E27095C602DF /* CoachingUpgradeCTA.swift */; };
 		58E8E8A407F4BD8E6567E636 /* GamePlayViewModel+Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED535AE485D4799B1F14DA57 /* GamePlayViewModel+Session.swift */; };
 		597339265F744D8A370418CD /* nn-37f18f62d772.nnue in Resources */ = {isa = PBXBuildFile; fileRef = AABA327DF4FE44334C2F8676 /* nn-37f18f62d772.nnue */; };
 		5A5DBC756BCF86FA250B4BBF /* AssessmentPuzzleValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC42EBAD0A1EB01244063C2 /* AssessmentPuzzleValidationTests.swift */; };
@@ -174,6 +176,7 @@
 		CF307670DC327797093F7208 /* grunfeld.json in Resources */ = {isa = PBXBuildFile; fileRef = 933464258B1545E31EDF5A78 /* grunfeld.json */; };
 		CF36525240E3E620133DA978 /* StreakTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D184D947DB9D9436C3D6C2DA /* StreakTracker.swift */; };
 		D0BC302F30C5D0BD8C66567F /* TrainerCoachingEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0233CE2A8A4E762B9378EF3 /* TrainerCoachingEntry.swift */; };
+		D10DC07C7BDE52B4FD477997 /* CoachingTierBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9771544407D2F3F130FDD867 /* CoachingTierBadge.swift */; };
 		D1FEED3A57EB66EA906EF23B /* StyleProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F333AA1C97FC6A0D14D477 /* StyleProfile.swift */; };
 		D5A858DE2FAAEE20F0924CA0 /* BoardThemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86FBB9BDC37A20F91CEAE32 /* BoardThemePickerView.swift */; };
 		D6068133A40E913B76E10636 /* scotch.json in Resources */ = {isa = PBXBuildFile; fileRef = 0F310D58804C675A6B99B98A /* scotch.json */; };
@@ -265,6 +268,7 @@
 		28B4A2582942F5C8B3786338 /* OpeningDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningDetailView.swift; sourceTree = "<group>"; };
 		2A7CD82D7AF05F3BB759479B /* assessment_puzzles.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = assessment_puzzles.json; sourceTree = "<group>"; };
 		2BC874EC3E7E86991AB1C047 /* TrainerGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainerGame.swift; sourceTree = "<group>"; };
+		2C137CFBA1FFE261F6FEBB1E /* CoachingTierBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachingTierBadgeTests.swift; sourceTree = "<group>"; };
 		2CD82359955074892F6D0D84 /* vienna.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = vienna.json; sourceTree = "<group>"; };
 		2D38846C538E23A6BABEA968 /* CoachingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachingServiceTests.swift; sourceTree = "<group>"; };
 		2F73826204613AFF30C6BE78 /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
@@ -299,6 +303,7 @@
 		4D3394090AB7EA057C3B70C3 /* Opening.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Opening.swift; sourceTree = "<group>"; };
 		4D5BC5D7B59BA70529A36D27 /* benoni.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = benoni.json; sourceTree = "<group>"; };
 		4E3A28BF244F5905997ACD78 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
+		4E6309E9D0A1E27095C602DF /* CoachingUpgradeCTA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachingUpgradeCTA.swift; sourceTree = "<group>"; };
 		4E6EE090BCC8A2BB794E7999 /* SessionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionResult.swift; sourceTree = "<group>"; };
 		4E8AEA095744E391EBCC764E /* LessonQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonQuiz.swift; sourceTree = "<group>"; };
 		4F5C7909A7C6642F8270FD00 /* OpponentPersonality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpponentPersonality.swift; sourceTree = "<group>"; };
@@ -352,6 +357,7 @@
 		94FA477EB260CEEAFC00FD0D /* kings-indian-attack.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "kings-indian-attack.json"; sourceTree = "<group>"; };
 		961F8FE3E5223459C2589B33 /* PlayersBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersBar.swift; sourceTree = "<group>"; };
 		96B6B01BE109AFA78A7EF936 /* b.tsv */ = {isa = PBXFileReference; path = b.tsv; sourceTree = "<group>"; };
+		9771544407D2F3F130FDD867 /* CoachingTierBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachingTierBadge.swift; sourceTree = "<group>"; };
 		979F3E8E88EC13BD44B5CA41 /* LLMTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMTypes.swift; sourceTree = "<group>"; };
 		97BD0870210FE31A28B4B382 /* SessionTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTypes.swift; sourceTree = "<group>"; };
 		97D53FEC7503128FABA4EACB /* OpeningSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningSettingsView.swift; sourceTree = "<group>"; };
@@ -641,6 +647,8 @@
 			isa = PBXGroup;
 			children = (
 				71EBE2AEE3B7EBB83DF63AFE /* CoachingFeedView.swift */,
+				9771544407D2F3F130FDD867 /* CoachingTierBadge.swift */,
+				4E6309E9D0A1E27095C602DF /* CoachingUpgradeCTA.swift */,
 				8B793529E6492F567719924C /* DeviationBanner.swift */,
 				3E73241D84FBAAFE368D13EE /* FeedEntry.swift */,
 				63C704CC666FF7E1E764A83C /* FeedRowCard.swift */,
@@ -687,6 +695,7 @@
 		5C21ACFDC3D1A4B4F24E7D37 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2C137CFBA1FFE261F6FEBB1E /* CoachingTierBadgeTests.swift */,
 				FDC7551DFA272832EC2159E0 /* OpeningIndicatorBannerTests.swift */,
 			);
 			path = Views;
@@ -1228,6 +1237,7 @@
 				5A5DBC756BCF86FA250B4BBF /* AssessmentPuzzleValidationTests.swift in Sources */,
 				0D39B083CA933D33F7E6D690 /* ChessCoachTests.swift in Sources */,
 				F67A6F94506D97F3671C024E /* CoachingServiceTests.swift in Sources */,
+				183B67ABB65A4C2EC41B945D /* CoachingTierBadgeTests.swift in Sources */,
 				6BC80A5EB034A34A73227B1F /* CurriculumLineTests.swift in Sources */,
 				28AB50F1F6466F64A554476F /* CurriculumServiceTests.swift in Sources */,
 				0B07A869013B5D2B9B20A5F3 /* GameStateTests.swift in Sources */,
@@ -1275,6 +1285,8 @@
 				A69BD20CA33336E911419A52 /* CoachingEntry.swift in Sources */,
 				9A9CA3121924438AE3442E11 /* CoachingFeedView.swift in Sources */,
 				4A7034C003AE7DE4915EB4C1 /* CoachingService.swift in Sources */,
+				D10DC07C7BDE52B4FD477997 /* CoachingTierBadge.swift in Sources */,
+				58DFC4A7DD236BD5C5432FB8 /* CoachingUpgradeCTA.swift in Sources */,
 				8CE08A1FABED074CF7F2E648 /* CoachingValidator.swift in Sources */,
 				F3D3B47863D2144F4DAD6013 /* ConceptIntroView.swift in Sources */,
 				8F93E8F84501F3C0DC684C39 /* ConfettiView.swift in Sources */,

--- a/ChessCoach.xcodeproj/project.pbxproj
+++ b/ChessCoach.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		A24FB0E1A9DB8C5A87C70E6C /* BetaWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9185A76CCA23DFDCF1A426E8 /* BetaWelcomeView.swift */; };
 		A2BF1CDCF901BA3987106EA4 /* LessonStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEFF49BF6F36ADFDFF5B260 /* LessonStep.swift */; };
 		A3B6271A8771F673FA5A6914 /* TokenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74ACFC1FF51C421C31619C19 /* TokenService.swift */; };
+		A5949FDC7113495618498B37 /* OffBookCoachingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926EE7B64B2172A475430164 /* OffBookCoachingService.swift */; };
 		A69BD20CA33336E911419A52 /* CoachingEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF629A861651E0D6B0F90507 /* CoachingEntry.swift */; };
 		A83EDE3FF2558974E8053DDA /* colle.json in Resources */ = {isa = PBXBuildFile; fileRef = C9E0D00426D51F255692AF98 /* colle.json */; };
 		A8709D770A6275E437B9E05B /* MoveArrowOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2D65DF5788AE7C8BDB8D95 /* MoveArrowOverlay.swift */; };
@@ -196,6 +197,7 @@
 		FB40683F90B2493DD3C10B18 /* FeedRowCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C704CC666FF7E1E764A83C /* FeedRowCard.swift */; };
 		FB79B4BFE016B65FB6C99F67 /* ShakeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE84EB8D6F28395CA6D20D47 /* ShakeModifier.swift */; };
 		FF125D4E0D68D791E1BF1211 /* OpponentPersonality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5C7909A7C6642F8270FD00 /* OpponentPersonality.swift */; };
+		FF1C97579B3EFDE64118941E /* OffBookCoachingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316C3C4B6A21C5ECFB7412EB /* OffBookCoachingServiceTests.swift */; };
 		FF312B0A04CB97D763D063F6 /* GameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25353786D741F85FF2823848 /* GameState.swift */; };
 		FF3325E9F81F395A63999BE8 /* kings-indian.json in Resources */ = {isa = PBXBuildFile; fileRef = 80B494BD63159C166BB480D6 /* kings-indian.json */; };
 		FFD927F3EE333129D098778B /* SessionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6EE090BCC8A2BB794E7999 /* SessionResult.swift */; };
@@ -266,6 +268,7 @@
 		2F73826204613AFF30C6BE78 /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
 		31123546082CDFF2D06CA159 /* ChessCoachUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = ChessCoachUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		31501E26BAA6604484201596 /* french.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = french.json; sourceTree = "<group>"; };
+		316C3C4B6A21C5ECFB7412EB /* OffBookCoachingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffBookCoachingServiceTests.swift; sourceTree = "<group>"; };
 		3175B096AC5C4CC89EC1CCD5 /* ELOAssessmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ELOAssessmentView.swift; sourceTree = "<group>"; };
 		332F891136AFED8AAB292209 /* OpponentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpponentResponse.swift; sourceTree = "<group>"; };
 		336300F72FB21993A4A91474 /* GameAnalysisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameAnalysisService.swift; sourceTree = "<group>"; };
@@ -340,6 +343,7 @@
 		9184DFCBC4771D026AF80AA2 /* reti.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reti.json; sourceTree = "<group>"; };
 		9185A76CCA23DFDCF1A426E8 /* BetaWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaWelcomeView.swift; sourceTree = "<group>"; };
 		9214431E18C24CB2D5B9518F /* SpacedRepScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepScheduler.swift; sourceTree = "<group>"; };
+		926EE7B64B2172A475430164 /* OffBookCoachingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffBookCoachingService.swift; sourceTree = "<group>"; };
 		933464258B1545E31EDF5A78 /* grunfeld.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = grunfeld.json; sourceTree = "<group>"; };
 		93F01EB13F3A5591B7E7C204 /* PlanScoringService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanScoringService.swift; sourceTree = "<group>"; };
 		94FA477EB260CEEAFC00FD0D /* kings-indian-attack.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "kings-indian-attack.json"; sourceTree = "<group>"; };
@@ -552,6 +556,7 @@
 				3F3E90E0981675812A48489A /* HolisticDetector.swift */,
 				C37CCC5EF67DA0B6FF9A4F11 /* KeychainService.swift */,
 				BD3017C504F70C847181883F /* ModelDownloadService.swift */,
+				926EE7B64B2172A475430164 /* OffBookCoachingService.swift */,
 				0861086E6D627EA6E845286A /* OpeningDetector.swift */,
 				4C2FE0FAE5C3A682629D3BBD /* PersistenceService.swift */,
 				D59F10FB0632A5493AAF263C /* PGNParser.swift */,
@@ -874,6 +879,7 @@
 				163FB854AB6EFAC989181AAF /* CurriculumLineTests.swift */,
 				DB2780834A4769F1B85115C8 /* CurriculumServiceTests.swift */,
 				B43293FAD4058537CD08C844 /* LLMServiceTests.swift */,
+				316C3C4B6A21C5ECFB7412EB /* OffBookCoachingServiceTests.swift */,
 				7AD43C08072479F064D8D2F3 /* PersistenceMigrationTests.swift */,
 			);
 			path = Services;
@@ -1212,6 +1218,7 @@
 				28AB50F1F6466F64A554476F /* CurriculumServiceTests.swift in Sources */,
 				0B07A869013B5D2B9B20A5F3 /* GameStateTests.swift in Sources */,
 				153407464C23E1214B8097CA /* LLMServiceTests.swift in Sources */,
+				FF1C97579B3EFDE64118941E /* OffBookCoachingServiceTests.swift in Sources */,
 				9088B40A68C9CAA472A56AC1 /* OpeningDatabaseTests.swift in Sources */,
 				E8EB6F8BD6792748DF4BD638 /* OpeningTests.swift in Sources */,
 				9A02F7CA0B5E5DB2D7028B52 /* PersistenceMigrationTests.swift in Sources */,
@@ -1307,6 +1314,7 @@
 				A8709D770A6275E437B9E05B /* MoveArrowOverlay.swift in Sources */,
 				42D306A93F080E0BF519FD8E /* MoveFeedbackView.swift in Sources */,
 				FA80FB61085AB7ABBFF49182 /* MultiArrowOverlay.swift in Sources */,
+				A5949FDC7113495618498B37 /* OffBookCoachingService.swift in Sources */,
 				6BBB8C92AA455B052EB164BF /* OnDeviceLLMService.swift in Sources */,
 				2D036B0A371648AB3D3A7501 /* OnboardingView.swift in Sources */,
 				769D5BF52DD2376B9A0785B4 /* Opening.swift in Sources */,

--- a/ChessCoach/Components/Bars/OpeningIndicatorBanner.swift
+++ b/ChessCoach/Components/Bars/OpeningIndicatorBanner.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import ChessKit
+
+/// Shows both sides' detected openings during play.
+/// Layout: "You: Italian Game" left, separator, "Opp: Two Knights" right.
+struct OpeningIndicatorBanner: View {
+    let whiteOpening: String?
+    let blackOpening: String?
+    let playerColor: PieceColor
+
+    private var isVisible: Bool {
+        whiteOpening != nil || blackOpening != nil
+    }
+
+    private var youLabel: String? {
+        playerColor == .white ? whiteOpening : blackOpening
+    }
+
+    private var oppLabel: String? {
+        playerColor == .white ? blackOpening : whiteOpening
+    }
+
+    private var youDotColor: Color {
+        playerColor == .white ? .white : Color(white: 0.3)
+    }
+
+    private var oppDotColor: Color {
+        playerColor == .white ? Color(white: 0.3) : .white
+    }
+
+    var body: some View {
+        if isVisible {
+            HStack(spacing: 0) {
+                if let youLabel {
+                    sideView(dot: youDotColor, label: "You", name: youLabel)
+                }
+
+                if youLabel != nil && oppLabel != nil {
+                    Text("|")
+                        .font(.caption2)
+                        .foregroundStyle(AppColor.tertiaryText)
+                        .padding(.horizontal, 6)
+                }
+
+                if let oppLabel {
+                    sideView(dot: oppDotColor, label: "Opp", name: oppLabel)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, AppSpacing.screenPadding)
+            .padding(.vertical, AppSpacing.xxs)
+            .background(AppColor.elevatedBackground)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityDescription)
+        }
+    }
+
+    private func sideView(dot: Color, label: String, name: String) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(dot)
+                .frame(width: 6, height: 6)
+            Text("\(label):")
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(AppColor.tertiaryText)
+            Text(name)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(AppColor.secondaryText)
+                .lineLimit(1)
+        }
+    }
+
+    private var accessibilityDescription: String {
+        var parts: [String] = []
+        if let youLabel { parts.append("You: \(youLabel)") }
+        if let oppLabel { parts.append("Opponent: \(oppLabel)") }
+        return parts.joined(separator: ". ")
+    }
+}

--- a/ChessCoach/Components/Feed/CoachingTierBadge.swift
+++ b/ChessCoach/Components/Feed/CoachingTierBadge.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Small badge indicating the coaching analysis tier: "Basic" or "AI Coach".
+struct CoachingTierBadge: View {
+    let isLLM: Bool
+
+    var label: String { isLLM ? "AI Coach" : "Basic" }
+
+    private var color: Color { isLLM ? AppColor.info : AppColor.tertiaryText }
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12), in: Capsule())
+            .accessibilityLabel("\(label) analysis")
+    }
+}

--- a/ChessCoach/Components/Feed/CoachingUpgradeCTA.swift
+++ b/ChessCoach/Components/Feed/CoachingUpgradeCTA.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Tappable prompt encouraging free-tier users to upgrade for deeper coaching analysis.
+struct CoachingUpgradeCTA: View {
+    @State private var showPaywall = false
+
+    var body: some View {
+        Button {
+            showPaywall = true
+        } label: {
+            HStack(spacing: AppSpacing.sm) {
+                Image(systemName: "sparkles")
+                    .font(.caption2)
+                    .foregroundStyle(AppColor.gold)
+                Text("Unlock deeper analysis")
+                    .font(.caption)
+                    .foregroundStyle(AppColor.secondaryText)
+                Spacer()
+                Text("Upgrade")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(AppColor.gold)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(AppColor.gold.opacity(0.12), in: Capsule())
+            }
+            .padding(.horizontal, AppSpacing.md)
+            .padding(.vertical, AppSpacing.sm)
+            .background(AppColor.gold.opacity(0.06), in: RoundedRectangle(cornerRadius: AppRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showPaywall) {
+            ProUpgradeView()
+        }
+    }
+}

--- a/ChessCoach/Components/Feed/FeedEntry.swift
+++ b/ChessCoach/Components/Feed/FeedEntry.swift
@@ -30,6 +30,9 @@ final class FeedEntry: Identifiable {
     var expectedUCI: String?
     var playedUCI: String?
 
+    // Coaching tier
+    var isLLMCoaching: Bool = false
+
     // On-demand LLM explanation
     var explanation: String?
     var isExplaining: Bool = false

--- a/ChessCoach/Components/Feed/FeedRowCard.swift
+++ b/ChessCoach/Components/Feed/FeedRowCard.swift
@@ -88,6 +88,9 @@ struct FeedRowCard: View {
             }
 
             if let primary = pair.primaryEntry {
+                if !primary.coaching.isEmpty {
+                    CoachingTierBadge(isLLM: primary.isLLMCoaching)
+                }
                 categoryBadge(primary)
             }
         }

--- a/ChessCoach/Config/PromptCatalog.swift
+++ b/ChessCoach/Config/PromptCatalog.swift
@@ -86,17 +86,18 @@ enum PromptCatalog {
         \(guidance)
 
         IMPORTANT: REFS must ONLY list squares where pieces currently sit on the board.
+        IMPORTANT: Your coaching is for the STUDENT (\(studentColor)). Tell them what THEY should do next, not what the opponent should do. Never suggest the opponent's best move as the student's move.
 
         Respond with ONLY:
         REFS: <up to 3 key squares with pieces on them>
-        COACHING: <one sentence from the student's perspective>
+        COACHING: <one sentence addressed to the student who plays \(studentColor), about what THEY should do>
         """
     }
 
     /// Wrapper prompt for coaching both user + opponent moves in a single LLM call.
     static func batchedPrompt(userPrompt: String, opponentPrompt: String) -> String {
         """
-        You will provide coaching for TWO consecutive moves. Respond with BOTH sections.
+        You will provide coaching for TWO consecutive moves. Both coaching messages are for the STUDENT — tell them what THEY should know or do.
 
         === MOVE 1 (Student's move) ===
         \(userPrompt)
@@ -107,10 +108,10 @@ enum PromptCatalog {
         IMPORTANT: Format your response EXACTLY as:
         STUDENT:
         REFS: <piece references or "none">
-        COACHING: <coaching text>
+        COACHING: <coaching text for the student about their move>
         OPPONENT:
         REFS: <piece references or "none">
-        COACHING: <coaching text>
+        COACHING: <coaching text for the student about the opponent's move — what should the STUDENT do next>
         """
     }
 

--- a/ChessCoach/Config/PromptCatalog.swift
+++ b/ChessCoach/Config/PromptCatalog.swift
@@ -46,13 +46,30 @@ enum PromptCatalog {
         let studentColor = context.studentColor ?? "White"
         let opponentColor = studentColor == "White" ? "Black" : "White"
 
-        let guidance: String
+        var guidance: String
         if context.moveCategory == .deviation, let name = context.matchedResponseName, let adj = context.matchedResponseAdjustment {
             guidance = "The opponent played the \(name) variation (\(context.lastMove)). Plan adjustment: \(adj). Explain what this means for the student."
         } else if context.moveCategory == .deviation {
             guidance = "The opponent (\(opponentColor)) deviated from the \(context.openingName) by playing \(context.lastMove). Explain that the student is now out of book."
         } else {
             guidance = "The opponent (\(opponentColor)) played \(context.lastMove). Explain what this move means for the student (\(studentColor))."
+        }
+
+        if let category = context.deviationCategory {
+            switch category {
+            case .tempoWaste:
+                guidance += " The opponent wasted a tempo by moving the same piece twice."
+            case .centerConcession:
+                guidance += " The opponent has conceded the center — no opponent pawns on d4/d5/e4/e5."
+            case .delayedDevelopment:
+                guidance += " The opponent is behind in development with multiple minor pieces still on the back rank."
+            case .delayedCastling:
+                guidance += " The opponent has not castled and their king may be vulnerable."
+            case .knownAlternative(let name):
+                guidance += " The opponent is playing the \(name)."
+            case .unclassified:
+                break
+            }
         }
 
         let personalityNote = context.coachPersonalityPrompt.map { "Style: \($0)\n" } ?? ""

--- a/ChessCoach/Models/GamePlay/SessionTypes.swift
+++ b/ChessCoach/Models/GamePlay/SessionTypes.swift
@@ -27,7 +27,7 @@ struct ExplainContext {
     let hasPlayed: Bool
 }
 
-enum BookStatus: Equatable {
+enum BookStatus: Equatable, Sendable {
     case onBook
     case userDeviated(expected: OpeningMove, atPly: Int)
     case opponentDeviated(expected: OpeningMove, playedSAN: String, atPly: Int)

--- a/ChessCoach/Services/CoachingService/CoachingService.swift
+++ b/ChessCoach/Services/CoachingService/CoachingService.swift
@@ -4,6 +4,7 @@ actor CoachingService {
     private let llmService: any TextGenerating
     private let curriculumService: CurriculumService
     private let featureAccess: any FeatureAccessProviding
+    private let offBookService = OffBookCoachingService()
 
     init(llmService: any TextGenerating, curriculumService: CurriculumService, featureAccess: any FeatureAccessProviding) {
         self.llmService = llmService
@@ -330,7 +331,7 @@ actor CoachingService {
         if let bookStatus = context.bookStatus, let opening = context.opening {
             switch bookStatus {
             case .offBook, .userDeviated, .opponentDeviated:
-                let service = OffBookCoachingService()
+                let service = offBookService
                 let deviationPly: Int
                 switch bookStatus {
                 case .userDeviated(_, let p): deviationPly = p

--- a/ChessCoach/Services/CoachingService/CoachingService.swift
+++ b/ChessCoach/Services/CoachingService/CoachingService.swift
@@ -18,7 +18,7 @@ actor CoachingService {
     }
 
     /// Get coaching text for a move.
-    /// When LLM coaching is not unlocked, returns hardcoded fallback coaching only (no LLM call).
+    /// When LLM coaching is not unlocked, returns template coaching only (no LLM call).
     func getCoaching(
         fen: String,
         lastMove: String,
@@ -102,7 +102,7 @@ actor CoachingService {
     }
 
     /// Get batched coaching for both user and opponent moves in a single LLM call.
-    /// When LLM coaching is not unlocked, returns hardcoded fallback coaching only.
+    /// When LLM coaching is not unlocked, returns template coaching only.
     func getBatchedCoaching(
         userFen: String,
         userMove: String,
@@ -330,22 +330,28 @@ actor CoachingService {
         // Off-book: delegate to plan-based guidance
         if let bookStatus = context.bookStatus, let opening = context.opening {
             switch bookStatus {
-            case .offBook, .userDeviated, .opponentDeviated:
-                let service = offBookService
-                let deviationPly: Int
-                switch bookStatus {
-                case .userDeviated(_, let p): deviationPly = p
-                case .opponentDeviated(_, _, let p): deviationPly = p
-                case .offBook(let p): deviationPly = p
-                default: deviationPly = context.plyNumber
+            case .offBook(let p), .userDeviated(_, let p), .opponentDeviated(_, _, let p):
+                let opponentDev: (played: String, expected: String)?
+                if case .opponentDeviated(let expected, let played, _) = bookStatus {
+                    opponentDev = (played: played, expected: expected.san)
+                } else {
+                    opponentDev = nil
                 }
-                let guidance = service.generateGuidance(
+                let guidance = offBookService.generateGuidance(
                     fen: context.fen,
                     opening: opening,
-                    deviationPly: deviationPly,
-                    moveHistory: []
+                    deviationPly: p,
+                    moveHistory: [],
+                    opponentDeviation: opponentDev
                 )
-                return "\(guidance.summary) \(guidance.planReminder)"
+                var text = guidance.summary
+                if !guidance.planReminder.isEmpty {
+                    text += " \(guidance.planReminder)"
+                }
+                if let suggestion = guidance.suggestion {
+                    text += " \(suggestion)"
+                }
+                return text
             case .onBook:
                 break
             }

--- a/ChessCoach/Services/CoachingService/CoachingService.swift
+++ b/ChessCoach/Services/CoachingService/CoachingService.swift
@@ -72,13 +72,25 @@ actor CoachingService {
             category = moveCategory
         }
 
+        var deviationCategory: DeviationCategory? = nil
+        if let bs = bookStatus {
+            switch bs {
+            case .onBook: break
+            default:
+                deviationCategory = OffBookCoachingService.classifyDeviation(
+                    fen: fen, moveHistory: [], playerIsWhite: studentColor == "White"
+                )
+            }
+        }
+
         let context = buildContext(
             fen: fen, lastMove: lastMove, scoreBefore: scoreBefore, scoreAfter: scoreAfter,
             ply: ply, userELO: userELO, moveHistory: moveHistory,
             isUserMove: isUserMove, studentColor: studentColor, category: category,
             matchedResponseName: matchedResponseName,
             matchedResponseAdjustment: matchedResponseAdjustment,
-            bookStatus: bookStatus
+            bookStatus: bookStatus,
+            deviationCategory: deviationCategory
         )
 
         do {
@@ -289,7 +301,8 @@ actor CoachingService {
         ply: Int, userELO: Int, moveHistory: String,
         isUserMove: Bool, studentColor: String?, category: MoveCategory,
         matchedResponseName: String? = nil, matchedResponseAdjustment: String? = nil,
-        bookStatus: BookStatus? = nil
+        bookStatus: BookStatus? = nil,
+        deviationCategory: DeviationCategory? = nil
     ) -> CoachingContext {
         let opening = curriculumService.opening
         let expectedMove = opening.expectedMove(atPly: ply)
@@ -322,7 +335,8 @@ actor CoachingService {
             matchedResponseAdjustment: matchedResponseAdjustment,
             coachPersonalityPrompt: personality.personalityPrompt,
             opening: opening,
-            bookStatus: bookStatus
+            bookStatus: bookStatus,
+            deviationCategory: deviationCategory
         )
     }
 

--- a/ChessCoach/Services/CoachingService/CoachingService.swift
+++ b/ChessCoach/Services/CoachingService/CoachingService.swift
@@ -331,27 +331,13 @@ actor CoachingService {
         if let bookStatus = context.bookStatus, let opening = context.opening {
             switch bookStatus {
             case .offBook(let p), .userDeviated(_, let p), .opponentDeviated(_, _, let p):
-                let opponentDev: (played: String, expected: String)?
-                if case .opponentDeviated(let expected, let played, _) = bookStatus {
-                    opponentDev = (played: played, expected: expected.san)
-                } else {
-                    opponentDev = nil
-                }
                 let guidance = offBookService.generateGuidance(
                     fen: context.fen,
                     opening: opening,
                     deviationPly: p,
-                    moveHistory: [],
-                    opponentDeviation: opponentDev
+                    moveHistory: []
                 )
-                var text = guidance.summary
-                if !guidance.planReminder.isEmpty {
-                    text += " \(guidance.planReminder)"
-                }
-                if let suggestion = guidance.suggestion {
-                    text += " \(suggestion)"
-                }
-                return text
+                return guidance.templateCoaching
             case .onBook:
                 break
             }

--- a/ChessCoach/Services/CoachingService/CoachingService.swift
+++ b/ChessCoach/Services/CoachingService/CoachingService.swift
@@ -29,7 +29,8 @@ actor CoachingService {
         isUserMove: Bool = true,
         studentColor: String? = nil,
         matchedResponseName: String? = nil,
-        matchedResponseAdjustment: String? = nil
+        matchedResponseAdjustment: String? = nil,
+        bookStatus: BookStatus? = nil
     ) async -> String? {
         let moveCategory = curriculumService.categorizeUserMove(
             atPly: ply,
@@ -52,9 +53,10 @@ actor CoachingService {
                 isUserMove: isUserMove, studentColor: studentColor,
                 category: isUserMove ? moveCategory : (curriculumService.isDeviation(atPly: ply, move: lastMove) ? .deviation : .opponentMove),
                 matchedResponseName: matchedResponseName,
-                matchedResponseAdjustment: matchedResponseAdjustment
+                matchedResponseAdjustment: matchedResponseAdjustment,
+                bookStatus: bookStatus
             )
-            return fallbackCoaching(for: context)
+            return freeCoaching(for: context)
         }
 
         // Use the isUserMove flag passed from SessionViewModel
@@ -74,7 +76,8 @@ actor CoachingService {
             ply: ply, userELO: userELO, moveHistory: moveHistory,
             isUserMove: isUserMove, studentColor: studentColor, category: category,
             matchedResponseName: matchedResponseName,
-            matchedResponseAdjustment: matchedResponseAdjustment
+            matchedResponseAdjustment: matchedResponseAdjustment,
+            bookStatus: bookStatus
         )
 
         do {
@@ -87,7 +90,7 @@ actor CoachingService {
                 #if DEBUG
                 print("[ChessCoach] Hallucination detected in coaching, using fallback")
                 #endif
-                return fallbackCoaching(for: context)
+                return freeCoaching(for: context)
             }
         } catch {
             #if DEBUG
@@ -110,7 +113,8 @@ actor CoachingService {
         scoreAfter: Int,
         userELO: Int,
         moveHistory: String,
-        studentColor: String?
+        studentColor: String?,
+        bookStatus: BookStatus? = nil
     ) async -> (userCoaching: String?, opponentCoaching: String?) {
         let userMoveCategory = curriculumService.categorizeUserMove(
             atPly: userPly, move: userMove, stockfishScore: scoreAfter - scoreBefore
@@ -132,31 +136,35 @@ actor CoachingService {
             let uc = buildContext(
                 fen: userFen, lastMove: userMove, scoreBefore: scoreBefore, scoreAfter: scoreAfter,
                 ply: userPly, userELO: userELO, moveHistory: moveHistory,
-                isUserMove: true, studentColor: studentColor, category: userCategory
+                isUserMove: true, studentColor: studentColor, category: userCategory,
+                bookStatus: bookStatus
             )
             let oc = buildContext(
                 fen: opponentFen, lastMove: opponentMove, scoreBefore: 0, scoreAfter: 0,
                 ply: opponentPly, userELO: userELO, moveHistory: moveHistory,
-                isUserMove: false, studentColor: studentColor, category: opponentCategory
+                isUserMove: false, studentColor: studentColor, category: opponentCategory,
+                bookStatus: bookStatus
             )
             let shouldCoachUser = shouldCoach(moveCategory: userCategory)
             let shouldCoachOpponent = shouldCoach(moveCategory: opponentCategory)
             return (
-                shouldCoachUser ? fallbackCoaching(for: uc) : nil,
-                shouldCoachOpponent ? fallbackCoaching(for: oc) : nil
+                shouldCoachUser ? freeCoaching(for: uc) : nil,
+                shouldCoachOpponent ? freeCoaching(for: oc) : nil
             )
         }
 
         let userContext = buildContext(
             fen: userFen, lastMove: userMove, scoreBefore: scoreBefore, scoreAfter: scoreAfter,
             ply: userPly, userELO: userELO, moveHistory: moveHistory,
-            isUserMove: true, studentColor: studentColor, category: userCategory
+            isUserMove: true, studentColor: studentColor, category: userCategory,
+            bookStatus: bookStatus
         )
 
         let opponentContext = buildContext(
             fen: opponentFen, lastMove: opponentMove, scoreBefore: 0, scoreAfter: 0,
             ply: opponentPly, userELO: userELO, moveHistory: moveHistory,
-            isUserMove: false, studentColor: studentColor, category: opponentCategory
+            isUserMove: false, studentColor: studentColor, category: opponentCategory,
+            bookStatus: bookStatus
         )
 
         let shouldCoachUser = shouldCoach(moveCategory: userCategory)
@@ -185,7 +193,7 @@ actor CoachingService {
                 #if DEBUG
                 print("[ChessCoach] Hallucination detected in user coaching, using fallback")
                 #endif
-                validatedUser = shouldCoachUser ? fallbackCoaching(for: userContext) : nil
+                validatedUser = shouldCoachUser ? freeCoaching(for: userContext) : nil
             }
 
             // Validate opponent coaching
@@ -197,7 +205,7 @@ actor CoachingService {
                 #if DEBUG
                 print("[ChessCoach] Hallucination detected in opponent coaching, using fallback")
                 #endif
-                validatedOpponent = shouldCoachOpponent ? fallbackCoaching(for: opponentContext) : nil
+                validatedOpponent = shouldCoachOpponent ? freeCoaching(for: opponentContext) : nil
             }
 
             return (validatedUser, validatedOpponent)
@@ -213,7 +221,7 @@ actor CoachingService {
                     let prompt = LLMService.buildPrompt(for: userContext)
                     let raw = try await llmService.generate(prompt: prompt, maxTokens: AppConfig.tokens.coaching)
                     let parsed = CoachingValidator.parse(response: raw)
-                    userResult = CoachingValidator.validate(parsed: parsed, fen: userFen) ?? fallbackCoaching(for: userContext)
+                    userResult = CoachingValidator.validate(parsed: parsed, fen: userFen) ?? freeCoaching(for: userContext)
                 } catch {
                     #if DEBUG
                     print("[ChessCoach] Single user coaching also failed: \(error)")
@@ -225,7 +233,7 @@ actor CoachingService {
                     let prompt = LLMService.buildPrompt(for: opponentContext)
                     let raw = try await llmService.generate(prompt: prompt, maxTokens: AppConfig.tokens.coaching)
                     let parsed = CoachingValidator.parse(response: raw)
-                    opponentResult = CoachingValidator.validate(parsed: parsed, fen: opponentFen) ?? fallbackCoaching(for: opponentContext)
+                    opponentResult = CoachingValidator.validate(parsed: parsed, fen: opponentFen) ?? freeCoaching(for: opponentContext)
                 } catch {
                     #if DEBUG
                     print("[ChessCoach] Single opponent coaching also failed: \(error)")
@@ -279,7 +287,8 @@ actor CoachingService {
         fen: String, lastMove: String, scoreBefore: Int, scoreAfter: Int,
         ply: Int, userELO: Int, moveHistory: String,
         isUserMove: Bool, studentColor: String?, category: MoveCategory,
-        matchedResponseName: String? = nil, matchedResponseAdjustment: String? = nil
+        matchedResponseName: String? = nil, matchedResponseAdjustment: String? = nil,
+        bookStatus: BookStatus? = nil
     ) -> CoachingContext {
         let opening = curriculumService.opening
         let expectedMove = opening.expectedMove(atPly: ply)
@@ -310,37 +319,71 @@ actor CoachingService {
             mainLineSoFar: mainLineSoFar,
             matchedResponseName: matchedResponseName,
             matchedResponseAdjustment: matchedResponseAdjustment,
-            coachPersonalityPrompt: personality.personalityPrompt
+            coachPersonalityPrompt: personality.personalityPrompt,
+            opening: opening,
+            bookStatus: bookStatus
         )
     }
 
-    private func fallbackCoaching(for context: CoachingContext) -> String? {
-        let personality = CoachPersonality.forOpening(curriculumService.opening)
+    private func freeCoaching(for context: CoachingContext) -> String? {
+        // Off-book: delegate to plan-based guidance
+        if let bookStatus = context.bookStatus, let opening = context.opening {
+            switch bookStatus {
+            case .offBook, .userDeviated, .opponentDeviated:
+                let service = OffBookCoachingService()
+                let deviationPly: Int
+                switch bookStatus {
+                case .userDeviated(_, let p): deviationPly = p
+                case .opponentDeviated(_, _, let p): deviationPly = p
+                case .offBook(let p): deviationPly = p
+                default: deviationPly = context.plyNumber
+                }
+                let guidance = service.generateGuidance(
+                    fen: context.fen,
+                    opening: opening,
+                    deviationPly: deviationPly,
+                    moveHistory: []
+                )
+                return "\(guidance.summary) \(guidance.planReminder)"
+            case .onBook:
+                break
+            }
+        }
 
+        // On-book: use opening move explanations
         if context.isUserMove {
+            if let explanation = context.expectedMoveExplanation, !explanation.isEmpty {
+                switch context.moveCategory {
+                case .goodMove:
+                    return explanation
+                case .okayMove:
+                    let expected = context.expectedMoveSAN ?? "the book move"
+                    return "The book move is \(expected). \(explanation)"
+                case .mistake:
+                    let expected = context.expectedMoveSAN ?? "the book move"
+                    return "The recommended move is \(expected). \(explanation)"
+                default:
+                    return nil
+                }
+            }
             switch context.moveCategory {
-            case .goodMove:
-                return personality.witticism(for: .goodMove)
+            case .goodMove: return "Good — that's the book move."
             case .okayMove:
                 let expected = context.expectedMoveSAN ?? "the book move"
-                let quip = personality.witticism(for: .okayMove)
-                return "\(quip) The book move is \(expected)."
+                return "The book move is \(expected)."
             case .mistake:
                 let expected = context.expectedMoveSAN ?? "the book move"
-                let quip = personality.witticism(for: .mistake)
-                return "\(quip) The recommended move here is \(expected)."
-            default:
-                return nil
+                return "The recommended move is \(expected)."
+            default: return nil
             }
         } else {
             if context.moveCategory == .deviation {
                 if let name = context.matchedResponseName, let adj = context.matchedResponseAdjustment {
                     return "Your opponent played the \(name). \(adj)"
                 }
-                return personality.witticism(for: .deviation)
-            } else {
-                return personality.witticism(for: .opponentMove)
+                return "Your opponent deviated from the main line."
             }
+            return nil
         }
     }
 }

--- a/ChessCoach/Services/LLMService/LLMTypes.swift
+++ b/ChessCoach/Services/LLMService/LLMTypes.swift
@@ -30,6 +30,7 @@ struct CoachingContext: Sendable {
     let coachPersonalityPrompt: String?
     let opening: Opening?
     let bookStatus: BookStatus?
+    let deviationCategory: DeviationCategory?
 }
 
 enum LLMProvider: Sendable {

--- a/ChessCoach/Services/LLMService/LLMTypes.swift
+++ b/ChessCoach/Services/LLMService/LLMTypes.swift
@@ -28,6 +28,8 @@ struct CoachingContext: Sendable {
     let matchedResponseName: String?
     let matchedResponseAdjustment: String?
     let coachPersonalityPrompt: String?
+    let opening: Opening?
+    let bookStatus: BookStatus?
 }
 
 enum LLMProvider: Sendable {

--- a/ChessCoach/Services/OffBookCoachingService.swift
+++ b/ChessCoach/Services/OffBookCoachingService.swift
@@ -1,0 +1,291 @@
+import Foundation
+
+/// Guidance generated when a game goes off-book (deviates from known opening theory).
+struct OffBookGuidance: Sendable {
+    /// e.g. "You left the Italian Game at move 7"
+    let summary: String
+    /// e.g. "The plan is to target f7 with your bishop"
+    let planReminder: String
+    /// e.g. "Consider developing your bishop to c4"
+    let suggestion: String?
+    /// Strategic goals that are still relevant given the current position
+    let relevantGoals: [StrategicGoal]
+}
+
+/// Generates plan-based coaching when the game goes off-book.
+///
+/// This service is pure logic — no LLM calls, no async. It inspects the FEN
+/// to determine which strategic goals and piece targets are still relevant,
+/// then builds human-readable guidance from the opening's plan.
+struct OffBookCoachingService: Sendable {
+
+    /// Generate coaching guidance for an off-book position.
+    ///
+    /// - Parameters:
+    ///   - fen: Current board position in FEN notation
+    ///   - opening: The opening the player was studying
+    ///   - deviationPly: The half-move (ply) at which the game went off-book
+    ///   - moveHistory: SAN move list up to this point
+    ///   - opponentDeviation: If the *opponent* deviated, what they played vs. expected
+    /// - Returns: Structured guidance for the coaching UI
+    func generateGuidance(
+        fen: String,
+        opening: Opening,
+        deviationPly: Int,
+        moveHistory: [String],
+        opponentDeviation: (played: String, expected: String)? = nil
+    ) -> OffBookGuidance {
+        guard let plan = opening.plan else {
+            return genericGuidance(opening: opening, deviationPly: deviationPly, opponentDeviation: opponentDeviation)
+        }
+
+        let board = FENParser.boardString(from: fen)
+        let isWhite = opening.color == .white
+
+        // 1. Filter strategic goals to those still relevant
+        let relevantGoals = plan.strategicGoals.filter { goal in
+            guard let condition = goal.checkCondition else {
+                // No condition means always relevant
+                return true
+            }
+            return !isConditionMet(condition, board: board, fen: fen, isWhite: isWhite)
+        }.sorted { $0.priority < $1.priority }
+
+        // 2. Find unmet piece targets
+        let unmetTargets = plan.pieceTargets.filter { target in
+            let pieceChar = Self.pieceChar(name: target.piece, isWhite: isWhite)
+            return !target.idealSquares.contains { square in
+                FENParser.isPieceOnSquare(piece: pieceChar, square: square, board: board)
+            }
+        }
+
+        // 3. Build summary
+        let moveNumber = (deviationPly / 2) + 1
+        let summary: String
+        if let deviation = opponentDeviation {
+            summary = "Your opponent left the \(opening.name) at move \(moveNumber) — they played \(deviation.played) instead of the expected \(deviation.expected)."
+        } else {
+            summary = "You left the \(opening.name) at move \(moveNumber)."
+        }
+
+        // 4. Build plan reminder
+        let planReminder = plan.summary
+
+        // 5. Build suggestion from unmet targets or top relevant goal
+        let suggestion: String?
+        if let firstUnmet = unmetTargets.first {
+            let squares = firstUnmet.idealSquares.joined(separator: " or ")
+            suggestion = "Consider developing your \(firstUnmet.piece) to \(squares) — \(firstUnmet.reasoning.lowercasedFirst)"
+        } else if let topGoal = relevantGoals.first {
+            suggestion = topGoal.description
+        } else {
+            suggestion = nil
+        }
+
+        return OffBookGuidance(
+            summary: summary,
+            planReminder: planReminder,
+            suggestion: suggestion,
+            relevantGoals: relevantGoals
+        )
+    }
+
+    // MARK: - Private
+
+    /// Generic guidance when the opening has no plan data.
+    private func genericGuidance(
+        opening: Opening,
+        deviationPly: Int,
+        opponentDeviation: (played: String, expected: String)?
+    ) -> OffBookGuidance {
+        let moveNumber = (deviationPly / 2) + 1
+        let summary: String
+        if let deviation = opponentDeviation {
+            summary = "Your opponent left the \(opening.name) at move \(moveNumber) — they played \(deviation.played) instead of the expected \(deviation.expected)."
+        } else {
+            summary = "You left the \(opening.name) at move \(moveNumber)."
+        }
+        return OffBookGuidance(
+            summary: summary,
+            planReminder: "Keep developing your pieces toward the center and castle early.",
+            suggestion: "Focus on getting your knights and bishops out before moving the same piece twice.",
+            relevantGoals: []
+        )
+    }
+
+    /// Check whether a condition string is already met in the current position.
+    private func isConditionMet(_ condition: String, board: String, fen: String, isWhite: Bool) -> Bool {
+        // bishop_on_diagonal_a2g8
+        if condition.hasPrefix("bishop_on_diagonal_") {
+            let diagonal = String(condition.dropFirst("bishop_on_diagonal_".count))
+            return FENParser.isBishopOnDiagonal(diagonal: diagonal, board: board, isWhite: isWhite)
+        }
+        // pawn_on_e4
+        if condition.hasPrefix("pawn_on_") {
+            let square = String(condition.dropFirst("pawn_on_".count))
+            let pawnChar: Character = isWhite ? "P" : "p"
+            return FENParser.isPieceOnSquare(piece: pawnChar, square: square, board: board)
+        }
+        // castled_kingside
+        if condition == "castled_kingside" {
+            return FENParser.isCastled(kingside: true, fen: fen, isWhite: isWhite)
+        }
+        // castled_queenside
+        if condition == "castled_queenside" {
+            return FENParser.isCastled(kingside: false, fen: fen, isWhite: isWhite)
+        }
+        // knight_on_f3, etc.
+        if condition.hasPrefix("knight_on_") {
+            let square = String(condition.dropFirst("knight_on_".count))
+            let knightChar: Character = isWhite ? "N" : "n"
+            return FENParser.isPieceOnSquare(piece: knightChar, square: square, board: board)
+        }
+        // Unknown condition — treat as not met (goal stays relevant)
+        return false
+    }
+
+    /// Map piece name to FEN character.
+    static func pieceChar(name: String, isWhite: Bool) -> Character {
+        let lower = name.lowercased()
+        let base: Character
+        if lower.contains("bishop") {
+            base = "B"
+        } else if lower.contains("knight") {
+            base = "N"
+        } else if lower.contains("rook") {
+            base = "R"
+        } else if lower.contains("queen") {
+            base = "Q"
+        } else if lower.contains("king") && !lower.contains("knight") {
+            base = "K"
+        } else if lower.contains("pawn") {
+            base = "P"
+        } else {
+            base = "P" // fallback
+        }
+        return isWhite ? base : Character(base.lowercased())
+    }
+}
+
+// MARK: - FEN Parsing Utilities
+
+/// Lightweight FEN parsing for positional checks — no full board representation needed.
+enum FENParser {
+
+    /// Extract just the board placement string (rank 8 down to rank 1) from a FEN.
+    static func boardString(from fen: String) -> String {
+        String(fen.prefix(while: { $0 != " " }))
+    }
+
+    /// Check if a specific piece character is on a specific square.
+    ///
+    /// - Parameters:
+    ///   - piece: FEN character, e.g. 'B' for white bishop, 'n' for black knight
+    ///   - square: Algebraic square, e.g. "c4"
+    ///   - board: FEN board string (ranks separated by '/')
+    static func isPieceOnSquare(piece: Character, square: String, board: String) -> Bool {
+        guard let (file, rank) = parseSquare(square) else { return false }
+        let ranks = board.split(separator: "/")
+        // FEN ranks go from 8 (index 0) to 1 (index 7)
+        let rankIndex = 7 - rank
+        guard rankIndex >= 0, rankIndex < ranks.count else { return false }
+        let rankStr = String(ranks[rankIndex])
+
+        var currentFile = 0
+        for ch in rankStr {
+            if ch.isNumber {
+                currentFile += ch.wholeNumberValue ?? 0
+            } else {
+                if currentFile == file && ch == piece {
+                    return true
+                }
+                currentFile += 1
+            }
+        }
+        return false
+    }
+
+    /// Check if any bishop (of the specified color) is on a named diagonal like "a2g8".
+    ///
+    /// The diagonal is specified by two corner squares, e.g. "a2g8" means
+    /// the diagonal from a2 to g8 (all squares where file + rank share the
+    /// same light/dark color and lie on that line).
+    static func isBishopOnDiagonal(diagonal: String, board: String, isWhite: Bool) -> Bool {
+        let diagonalSquares = squaresOnDiagonal(diagonal)
+        let bishopChar: Character = isWhite ? "B" : "b"
+        return diagonalSquares.contains { square in
+            isPieceOnSquare(piece: bishopChar, square: square, board: board)
+        }
+    }
+
+    /// Proxy check for castling via castling rights in FEN.
+    ///
+    /// If the player has lost castling rights on a given side, we assume they've castled
+    /// (or moved their king/rook, which is close enough for coaching purposes).
+    static func isCastled(kingside: Bool, fen: String, isWhite: Bool) -> Bool {
+        let parts = fen.split(separator: " ")
+        guard parts.count >= 3 else { return false }
+        let castling = String(parts[2])
+        if castling == "-" { return true } // All rights gone — likely castled
+        if isWhite {
+            let right: Character = kingside ? "K" : "Q"
+            return !castling.contains(right)
+        } else {
+            let right: Character = kingside ? "k" : "q"
+            return !castling.contains(right)
+        }
+    }
+
+    /// Parse an algebraic square like "c4" into (file: 2, rank: 3) — both 0-indexed.
+    static func parseSquare(_ square: String) -> (file: Int, rank: Int)? {
+        guard square.count == 2,
+              let fileChar = square.first,
+              let rankChar = square.last,
+              fileChar >= "a", fileChar <= "h",
+              let rankNum = rankChar.wholeNumberValue,
+              rankNum >= 1, rankNum <= 8 else {
+            return nil
+        }
+        let file = Int(fileChar.asciiValue! - Character("a").asciiValue!)
+        let rank = rankNum - 1
+        return (file, rank)
+    }
+
+    /// Compute all algebraic squares on a diagonal defined by two corner squares.
+    ///
+    /// e.g. "a2g8" → ["a2", "b3", "c4", "d5", "e6", "f7", "g8"]
+    static func squaresOnDiagonal(_ diagonal: String) -> [String] {
+        // Parse the two endpoint squares
+        let chars = Array(diagonal)
+        guard chars.count == 4 else { return [] }
+        let startSquare = String(chars[0...1])
+        let endSquare = String(chars[2...3])
+        guard let start = parseSquare(startSquare),
+              let end = parseSquare(endSquare) else { return [] }
+
+        let fileDelta = end.file > start.file ? 1 : -1
+        let rankDelta = end.rank > start.rank ? 1 : -1
+
+        var squares: [String] = []
+        var f = start.file
+        var r = start.rank
+        while f >= 0 && f <= 7 && r >= 0 && r <= 7 {
+            let fileChar = Character(UnicodeScalar(UInt8(f) + Character("a").asciiValue!))
+            squares.append("\(fileChar)\(r + 1)")
+            if f == end.file && r == end.rank { break }
+            f += fileDelta
+            r += rankDelta
+        }
+        return squares
+    }
+}
+
+// MARK: - String Helper
+
+private extension String {
+    /// Returns a copy with the first character lowercased.
+    var lowercasedFirst: String {
+        guard let first = self.first else { return self }
+        return first.lowercased() + self.dropFirst()
+    }
+}

--- a/ChessCoach/Services/OffBookCoachingService.swift
+++ b/ChessCoach/Services/OffBookCoachingService.swift
@@ -60,13 +60,7 @@ struct OffBookCoachingService: Sendable {
         }
 
         // 3. Build summary
-        let moveNumber = (deviationPly / 2) + 1
-        let summary: String
-        if let deviation = opponentDeviation {
-            summary = "Your opponent left the \(opening.name) at move \(moveNumber) — they played \(deviation.played) instead of the expected \(deviation.expected)."
-        } else {
-            summary = "You left the \(opening.name) at move \(moveNumber)."
-        }
+        let summary = buildSummary(opening: opening, deviationPly: deviationPly, opponentDeviation: opponentDeviation)
 
         // 4. Build plan reminder
         let planReminder = plan.summary
@@ -98,19 +92,26 @@ struct OffBookCoachingService: Sendable {
         deviationPly: Int,
         opponentDeviation: (played: String, expected: String)?
     ) -> OffBookGuidance {
-        let moveNumber = (deviationPly / 2) + 1
-        let summary: String
-        if let deviation = opponentDeviation {
-            summary = "Your opponent left the \(opening.name) at move \(moveNumber) — they played \(deviation.played) instead of the expected \(deviation.expected)."
-        } else {
-            summary = "You left the \(opening.name) at move \(moveNumber)."
-        }
+        let summary = buildSummary(opening: opening, deviationPly: deviationPly, opponentDeviation: opponentDeviation)
         return OffBookGuidance(
             summary: summary,
             planReminder: "Keep developing your pieces toward the center and castle early.",
             suggestion: "Focus on getting your knights and bishops out before moving the same piece twice.",
             relevantGoals: []
         )
+    }
+
+    private func buildSummary(
+        opening: Opening,
+        deviationPly: Int,
+        opponentDeviation: (played: String, expected: String)?
+    ) -> String {
+        let moveNumber = (deviationPly / 2) + 1
+        if let deviation = opponentDeviation {
+            return "Your opponent left the \(opening.name) at move \(moveNumber) — they played \(deviation.played) instead of the expected \(deviation.expected)."
+        } else {
+            return "You left the \(opening.name) at move \(moveNumber)."
+        }
     }
 
     /// Check whether a condition string is already met in the current position.

--- a/ChessCoach/Services/OffBookCoachingService.swift
+++ b/ChessCoach/Services/OffBookCoachingService.swift
@@ -30,14 +30,22 @@ enum DeviationCategory: Sendable, Equatable {
 
 /// Guidance generated when a game goes off-book (deviates from known opening theory).
 struct OffBookGuidance: Sendable {
-    /// e.g. "You left the Italian Game at move 7"
-    let summary: String
-    /// e.g. "The plan is to target f7 with your bishop"
+    let category: DeviationCategory
     let planReminder: String
-    /// e.g. "Consider developing your bishop to c4"
     let suggestion: String?
-    /// Strategic goals that are still relevant given the current position
     let relevantGoals: [StrategicGoal]
+
+    /// Category-driven coaching message for free-tier users.
+    var templateCoaching: String {
+        var text = category.templateMessage
+        if !planReminder.isEmpty {
+            text += " \(planReminder)"
+        }
+        if let suggestion {
+            text += " \(suggestion)"
+        }
+        return text
+    }
 }
 
 /// Generates plan-based coaching when the game goes off-book.
@@ -53,18 +61,24 @@ struct OffBookCoachingService: Sendable {
     ///   - fen: Current board position in FEN notation
     ///   - opening: The opening the player was studying
     ///   - deviationPly: The half-move (ply) at which the game went off-book
-    ///   - moveHistory: SAN move list up to this point
-    ///   - opponentDeviation: If the *opponent* deviated, what they played vs. expected
+    ///   - moveHistory: Coordinate move pairs up to this point
     /// - Returns: Structured guidance for the coaching UI
     func generateGuidance(
         fen: String,
         opening: Opening,
         deviationPly: Int,
-        moveHistory: [String],
-        opponentDeviation: (played: String, expected: String)? = nil
+        moveHistory: [(from: String, to: String)]
     ) -> OffBookGuidance {
+        let playerIsWhite = opening.color == .white
+        let category = Self.classifyDeviation(fen: fen, moveHistory: moveHistory, playerIsWhite: playerIsWhite)
+
         guard let plan = opening.plan else {
-            return genericGuidance(opening: opening, deviationPly: deviationPly, opponentDeviation: opponentDeviation)
+            return OffBookGuidance(
+                category: category,
+                planReminder: "Keep developing your pieces toward the center and castle early.",
+                suggestion: "Focus on getting your knights and bishops out before moving the same piece twice.",
+                relevantGoals: []
+            )
         }
 
         let board = FENParser.boardString(from: fen)
@@ -87,13 +101,10 @@ struct OffBookCoachingService: Sendable {
             }
         }
 
-        // 3. Build summary
-        let summary = buildSummary(opening: opening, deviationPly: deviationPly, opponentDeviation: opponentDeviation)
-
-        // 4. Build plan reminder
+        // 3. Build plan reminder
         let planReminder = plan.summary
 
-        // 5. Build suggestion from unmet targets or top relevant goal
+        // 4. Build suggestion from unmet targets or top relevant goal
         let suggestion: String?
         if let firstUnmet = unmetTargets.first {
             let squares = firstUnmet.idealSquares.joined(separator: " or ")
@@ -105,7 +116,7 @@ struct OffBookCoachingService: Sendable {
         }
 
         return OffBookGuidance(
-            summary: summary,
+            category: category,
             planReminder: planReminder,
             suggestion: suggestion,
             relevantGoals: relevantGoals
@@ -113,34 +124,6 @@ struct OffBookCoachingService: Sendable {
     }
 
     // MARK: - Private
-
-    /// Generic guidance when the opening has no plan data.
-    private func genericGuidance(
-        opening: Opening,
-        deviationPly: Int,
-        opponentDeviation: (played: String, expected: String)?
-    ) -> OffBookGuidance {
-        let summary = buildSummary(opening: opening, deviationPly: deviationPly, opponentDeviation: opponentDeviation)
-        return OffBookGuidance(
-            summary: summary,
-            planReminder: "Keep developing your pieces toward the center and castle early.",
-            suggestion: "Focus on getting your knights and bishops out before moving the same piece twice.",
-            relevantGoals: []
-        )
-    }
-
-    private func buildSummary(
-        opening: Opening,
-        deviationPly: Int,
-        opponentDeviation: (played: String, expected: String)?
-    ) -> String {
-        let moveNumber = (deviationPly / 2) + 1
-        if let deviation = opponentDeviation {
-            return "Your opponent left the \(opening.name) at move \(moveNumber) — they played \(deviation.played) instead of the expected \(deviation.expected)."
-        } else {
-            return "You left the \(opening.name) at move \(moveNumber)."
-        }
-    }
 
     /// Check whether a condition string is already met in the current position.
     private func isConditionMet(_ condition: String, board: String, fen: String, isWhite: Bool) -> Bool {

--- a/ChessCoach/Services/OffBookCoachingService.swift
+++ b/ChessCoach/Services/OffBookCoachingService.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+/// Classification of how an opponent deviated from book theory.
+enum DeviationCategory: Sendable, Equatable {
+    case tempoWaste
+    case centerConcession
+    case delayedDevelopment
+    case delayedCastling
+    case knownAlternative(name: String)
+    case unclassified
+
+    /// Free-tier coaching template for this deviation type.
+    var templateMessage: String {
+        switch self {
+        case .tempoWaste:
+            return "Your opponent moved the same piece twice. Keep developing — you have a tempo advantage."
+        case .centerConcession:
+            return "Your opponent hasn't contested the center. Your central control gives you the initiative."
+        case .delayedDevelopment:
+            return "Your opponent is behind in development. Keep developing and look for opportunities to open the position."
+        case .delayedCastling:
+            return "Your opponent hasn't castled yet. Consider opening the center to exploit their exposed king."
+        case .knownAlternative(let name):
+            return "Your opponent is playing the \(name)."
+        case .unclassified:
+            return "Your opponent played a move outside of book theory."
+        }
+    }
+}
+
 /// Guidance generated when a game goes off-book (deviates from known opening theory).
 struct OffBookGuidance: Sendable {
     /// e.g. "You left the Italian Game at move 7"
@@ -165,6 +193,77 @@ struct OffBookCoachingService: Sendable {
             base = "P" // fallback
         }
         return isWhite ? base : Character(base.lowercased())
+    }
+
+    /// Classify an opponent's deviation from book using positional heuristics.
+    static func classifyDeviation(
+        fen: String,
+        moveHistory: [(from: String, to: String)],
+        playerIsWhite: Bool
+    ) -> DeviationCategory {
+        let board = FENParser.boardString(from: fen)
+        let plyCount = moveHistory.count
+        let opponentIsWhite = !playerIsWhite
+
+        // 1. Tempo waste: opponent moved a piece back to where it came from,
+        //    or moved from the same origin square twice (in first 10 plies)
+        let opponentMoves = moveHistory.enumerated()
+            .filter { opponentIsWhite ? $0.offset % 2 == 0 : $0.offset % 2 == 1 }
+            .map { $0.element }
+
+        for i in 0..<opponentMoves.count {
+            for j in (i+1)..<opponentMoves.count {
+                if opponentMoves[i].to == opponentMoves[j].from &&
+                   opponentMoves[i].from == opponentMoves[j].to {
+                    return .tempoWaste
+                }
+                if opponentMoves[i].from == opponentMoves[j].from {
+                    return .tempoWaste
+                }
+            }
+        }
+
+        // 2. Center concession: opponent has no pawns on d4/d5/e4/e5 after ply 8
+        if plyCount >= 8 {
+            let opponentPawn: Character = opponentIsWhite ? "P" : "p"
+            let centerSquares = ["d4", "d5", "e4", "e5"]
+            let hasCenterPawn = centerSquares.contains { square in
+                FENParser.isPieceOnSquare(piece: opponentPawn, square: square, board: board)
+            }
+            if !hasCenterPawn {
+                return .centerConcession
+            }
+        }
+
+        // 3. Delayed development: 3+ opponent minor pieces still on back rank after ply 8
+        if plyCount >= 8 {
+            let minorPieceTypes: [(Character, [String])] = opponentIsWhite
+                ? [("N", ["b1", "g1"]), ("B", ["c1", "f1"])]
+                : [("n", ["b8", "g8"]), ("b", ["c8", "f8"])]
+
+            var homeCount = 0
+            for (piece, homeSquares) in minorPieceTypes {
+                for square in homeSquares {
+                    if FENParser.isPieceOnSquare(piece: piece, square: square, board: board) {
+                        homeCount += 1
+                    }
+                }
+            }
+            if homeCount >= 3 {
+                return .delayedDevelopment
+            }
+        }
+
+        // 4. Delayed castling: opponent hasn't castled by ply 14
+        if plyCount >= 14 {
+            let hasCastled = FENParser.isCastled(kingside: true, fen: fen, isWhite: opponentIsWhite)
+                || FENParser.isCastled(kingside: false, fen: fen, isWhite: opponentIsWhite)
+            if !hasCastled {
+                return .delayedCastling
+            }
+        }
+
+        return .unclassified
     }
 }
 

--- a/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
@@ -80,7 +80,7 @@ extension GamePlayViewModel {
             expectedSAN: expectedSAN,
             expectedUCI: expectedUCI
         )
-        updateOpeningDetectionWithFeed()
+        updateOpeningDetection()
 
         let category: MoveCategory = isDeviation ? .mistake : .goodMove
         maybeShowQuip(for: category)
@@ -400,7 +400,7 @@ extension GamePlayViewModel {
         )
 
         appendToFeed(ply: ply, san: opponentSan, coaching: opponentCoachingText, isDeviation: !isOnBook, fen: gameState.fen)
-        updateOpeningDetectionWithFeed()
+        updateOpeningDetection()
 
         if isOffBookHere {
             showOffBookGuidance()
@@ -547,7 +547,7 @@ extension GamePlayViewModel {
         )
 
         appendToFeed(ply: opponentPly, san: batchedOpponentSan, coaching: opponentCoachingText, isDeviation: !isOnBook, fen: gameState.fen)
-        updateOpeningDetectionWithFeed()
+        updateOpeningDetection()
 
         if gameState.plyCount >= moves.count {
             captureSnapshot()
@@ -761,28 +761,6 @@ extension GamePlayViewModel {
 
         showProactiveCoaching()
         captureSnapshot()
-    }
-
-    // MARK: - Opening Detection (Session)
-
-    /// Updates holistic opening detection and appends a feed entry when a new opening is detected.
-    func updateOpeningDetectionWithFeed() {
-        let oldWhite = holisticDetection.whiteFramework.primary?.opening.name
-        let oldBlack = holisticDetection.blackFramework.primary?.opening.name
-
-        updateOpeningDetection()
-
-        let newWhite = holisticDetection.whiteFramework.primary?.opening.name
-        let newBlack = holisticDetection.blackFramework.primary?.opening.name
-
-        if let name = newWhite, name != oldWhite {
-            let ply = gameState.plyCount
-            appendToFeed(ply: ply, san: nil, coaching: "White is playing the \(name).", isDeviation: false, fen: gameState.fen)
-        }
-        if let name = newBlack, name != oldBlack {
-            let ply = gameState.plyCount
-            appendToFeed(ply: ply, san: nil, coaching: "Black is playing the \(name).", isDeviation: false, fen: gameState.fen)
-        }
     }
 
     // MARK: - Feed Management

--- a/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
@@ -688,6 +688,12 @@ extension GamePlayViewModel {
         )
 
         userCoachingText = guidance.templateCoaching
+
+        // Show upgrade CTA once per session for free-tier users
+        if !isPro && !hasShownUpgradeCTA {
+            hasShownUpgradeCTA = true
+        }
+
         showOffBookArrowHint()
     }
 

--- a/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
@@ -680,27 +680,14 @@ extension GamePlayViewModel {
         default: deviationPly = currentPly
         }
 
-        var opponentDev: (played: String, expected: String)?
-        if case .opponentDeviated(let expected, let playedSAN, _) = bookStatus {
-            opponentDev = (played: playedSAN, expected: expected.san)
-        }
-
         let guidance = offBookCoachingService.generateGuidance(
             fen: gameState.fen,
             opening: opening,
             deviationPly: deviationPly,
-            moveHistory: gameState.moveHistory.map { $0.from + $0.to },
-            opponentDeviation: opponentDev
+            moveHistory: gameState.moveHistory.map { (from: $0.from, to: $0.to) }
         )
 
-        var text = guidance.summary
-        if !guidance.planReminder.isEmpty {
-            text += " \(guidance.planReminder)"
-        }
-        if let suggestion = guidance.suggestion {
-            text += " \(suggestion)"
-        }
-        userCoachingText = text
+        userCoachingText = guidance.templateCoaching
         showOffBookArrowHint()
     }
 

--- a/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
@@ -80,6 +80,7 @@ extension GamePlayViewModel {
             expectedSAN: expectedSAN,
             expectedUCI: expectedUCI
         )
+        updateOpeningDetectionWithFeed()
 
         let category: MoveCategory = isDeviation ? .mistake : .goodMove
         maybeShowQuip(for: category)
@@ -399,6 +400,7 @@ extension GamePlayViewModel {
         )
 
         appendToFeed(ply: ply, san: opponentSan, coaching: opponentCoachingText, isDeviation: !isOnBook, fen: gameState.fen)
+        updateOpeningDetectionWithFeed()
 
         if isOffBookHere {
             showOffBookGuidance()
@@ -543,6 +545,7 @@ extension GamePlayViewModel {
         )
 
         appendToFeed(ply: opponentPly, san: batchedOpponentSan, coaching: opponentCoachingText, isDeviation: !isOnBook, fen: gameState.fen)
+        updateOpeningDetectionWithFeed()
 
         if gameState.plyCount >= moves.count {
             captureSnapshot()
@@ -722,6 +725,28 @@ extension GamePlayViewModel {
 
         showProactiveCoaching()
         captureSnapshot()
+    }
+
+    // MARK: - Opening Detection (Session)
+
+    /// Updates holistic opening detection and appends a feed entry when a new opening is detected.
+    func updateOpeningDetectionWithFeed() {
+        let oldWhite = holisticDetection.whiteFramework.primary?.opening.name
+        let oldBlack = holisticDetection.blackFramework.primary?.opening.name
+
+        updateOpeningDetection()
+
+        let newWhite = holisticDetection.whiteFramework.primary?.opening.name
+        let newBlack = holisticDetection.blackFramework.primary?.opening.name
+
+        if let name = newWhite, name != oldWhite {
+            let ply = gameState.plyCount
+            appendToFeed(ply: ply, san: nil, coaching: "White is playing the \(name).", isDeviation: false, fen: gameState.fen)
+        }
+        if let name = newBlack, name != oldBlack {
+            let ply = gameState.plyCount
+            appendToFeed(ply: ply, san: nil, coaching: "Black is playing the \(name).", isDeviation: false, fen: gameState.fen)
+        }
     }
 
     // MARK: - Feed Management

--- a/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
@@ -472,7 +472,8 @@ extension GamePlayViewModel {
                     isUserMove: false,
                     studentColor: studentColor,
                     matchedResponseName: responseName,
-                    matchedResponseAdjustment: responseAdjustment
+                    matchedResponseAdjustment: responseAdjustment,
+                    bookStatus: self.bookStatus
                 )
             }
         }
@@ -656,16 +657,56 @@ extension GamePlayViewModel {
 
     func showOffBookGuidance() {
         guard isUserTurn, !sessionComplete else { return }
+        guard let opening = mode.opening else {
+            userCoachingText = "You're on your own. Focus on developing pieces and keeping your king safe."
+            showOffBookArrowHint()
+            return
+        }
 
+        // Throttle: only generate new guidance every 3 plies
+        let currentPly = gameState.plyCount
+        guard currentPly - offBookGuidanceLastPly >= 3 || offBookGuidanceLastPly < 0 else {
+            showOffBookArrowHint()
+            return
+        }
+        offBookGuidanceLastPly = currentPly
+
+        let deviationPly: Int
+        switch bookStatus {
+        case .userDeviated(_, let atPly): deviationPly = atPly
+        case .opponentDeviated(_, _, let atPly): deviationPly = atPly
+        case .offBook(let since): deviationPly = since
+        default: deviationPly = currentPly
+        }
+
+        var opponentDev: (played: String, expected: String)?
+        if case .opponentDeviated(let expected, let playedSAN, _) = bookStatus {
+            opponentDev = (played: playedSAN, expected: expected.san)
+        }
+
+        let guidance = offBookCoachingService.generateGuidance(
+            fen: gameState.fen,
+            opening: opening,
+            deviationPly: deviationPly,
+            moveHistory: gameState.moveHistory.map { $0.from + $0.to },
+            opponentDeviation: opponentDev
+        )
+
+        var text = guidance.summary
+        if !guidance.planReminder.isEmpty {
+            text += " \(guidance.planReminder)"
+        }
+        if let suggestion = guidance.suggestion {
+            text += " \(suggestion)"
+        }
+        userCoachingText = text
+        showOffBookArrowHint()
+    }
+
+    private func showOffBookArrowHint() {
         if mode.showsArrows, let hint = bestResponseHint, hint.count >= 4 {
             arrowFrom = String(hint.prefix(2))
             arrowTo = String(hint.dropFirst(2).prefix(2))
-        }
-
-        if let bestMove = bestResponseDescription {
-            userCoachingText = "You're on your own. Suggested: \(bestMove) — focus on development and king safety."
-        } else {
-            userCoachingText = "You're on your own. Focus on developing pieces and keeping your king safe."
         }
     }
 
@@ -710,6 +751,7 @@ extension GamePlayViewModel {
         branchPointOptions = nil
         suggestedVariation = nil
         lastMovePES = nil
+        offBookGuidanceLastPly = -10
         undoStack.removeAll()
         redoStack.removeAll()
         feedEntries.removeAll()
@@ -869,7 +911,8 @@ extension GamePlayViewModel {
             isUserMove: isUserMove,
             studentColor: mode.opening?.color == .white ? "White" : "Black",
             matchedResponseName: responseName,
-            matchedResponseAdjustment: responseAdjustment
+            matchedResponseAdjustment: responseAdjustment,
+            bookStatus: bookStatus
         )
 
         if let text {

--- a/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Session.swift
@@ -459,6 +459,7 @@ extension GamePlayViewModel {
 
             let capturedGen = gen
             let coaching = coachingService
+            let capturedBookStatus = bookStatus
             coachingTask = Task {
                 guard capturedGen == self.sessionGeneration else { return nil }
                 return await coaching.getCoaching(
@@ -473,7 +474,7 @@ extension GamePlayViewModel {
                     studentColor: studentColor,
                     matchedResponseName: responseName,
                     matchedResponseAdjustment: responseAdjustment,
-                    bookStatus: self.bookStatus
+                    bookStatus: capturedBookStatus
                 )
             }
         }

--- a/ChessCoach/ViewModels/GamePlayViewModel+Trainer.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel+Trainer.swift
@@ -196,8 +196,10 @@ extension GamePlayViewModel {
             case .mistake:
                 if !isBookMove, let bm = allPreBookMoves.first {
                     coaching = "\(personality.witticism(for: .mistake)) The recommended move here is \(bm.san)."
-                } else if let bestUCI = eval?.bestMove {
-                    let san = GameState.sanForUCI(bestUCI, inFEN: fen)
+                } else if let pmFen = preMoveFen,
+                          let bestUCI = await stockfish.bestMove(fen: pmFen, depth: AppConfig.engine.evalDepth) {
+                    // Evaluate from pre-move position to find the PLAYER's best alternative
+                    let san = GameState.sanForUCI(bestUCI, inFEN: pmFen)
                     coaching = "\(personality.witticism(for: .mistake)) Better was \(san)."
                 } else {
                     coaching = personality.witticism(for: .mistake)

--- a/ChessCoach/ViewModels/GamePlayViewModel.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel.swift
@@ -105,6 +105,8 @@ final class GamePlayViewModel {
     var hintTimer: Task<Void, Never>?
     var activeLine: OpeningLine?
     var activeLineID: String?
+    let offBookCoachingService = OffBookCoachingService()
+    var offBookGuidanceLastPly: Int = -10
 
     // ELO
     var userELO: Int = UserDefaults.standard.object(forKey: AppSettings.Key.userELO) as? Int ?? 600

--- a/ChessCoach/ViewModels/GamePlayViewModel.swift
+++ b/ChessCoach/ViewModels/GamePlayViewModel.swift
@@ -115,6 +115,7 @@ final class GamePlayViewModel {
     // Pro status
     var isPro: Bool = true
     var showProUpgrade = false
+    var hasShownUpgradeCTA = false
 
     // Haptic trigger
     var correctMoveTrigger: Int = 0

--- a/ChessCoach/Views/GamePlay/GamePlayView+TopBar.swift
+++ b/ChessCoach/Views/GamePlay/GamePlayView+TopBar.swift
@@ -129,6 +129,12 @@ extension GamePlayView {
                 coachLoadingBar
             }
         }
+
+        OpeningIndicatorBanner(
+            whiteOpening: viewModel.holisticDetection.whiteFramework.primary?.opening.name,
+            blackOpening: viewModel.holisticDetection.blackFramework.primary?.opening.name,
+            playerColor: viewModel.mode.playerColor
+        )
     }
 
     private var coachLoadingBar: some View {

--- a/ChessCoachTests/Services/LLMServiceTests.swift
+++ b/ChessCoachTests/Services/LLMServiceTests.swift
@@ -21,7 +21,9 @@ import Testing
         mainLineSoFar: "1. e4",
         matchedResponseName: nil,
         matchedResponseAdjustment: nil,
-        coachPersonalityPrompt: nil
+        coachPersonalityPrompt: nil,
+        opening: nil,
+        bookStatus: nil
     )
     let prompt = LLMService.buildPrompt(for: context)
     #expect(prompt.contains("e2e4"))
@@ -48,7 +50,9 @@ import Testing
         mainLineSoFar: "1. e4",
         matchedResponseName: nil,
         matchedResponseAdjustment: nil,
-        coachPersonalityPrompt: nil
+        coachPersonalityPrompt: nil,
+        opening: nil,
+        bookStatus: nil
     )
     let result = LLMService.buildPrompt(for: context)
     #expect(result.contains("correct"))
@@ -74,7 +78,9 @@ import Testing
         mainLineSoFar: "1. e4",
         matchedResponseName: nil,
         matchedResponseAdjustment: nil,
-        coachPersonalityPrompt: nil
+        coachPersonalityPrompt: nil,
+        opening: nil,
+        bookStatus: nil
     )
     let prompt = LLMService.buildPrompt(for: context)
     #expect(prompt.contains("e2e4"))

--- a/ChessCoachTests/Services/LLMServiceTests.swift
+++ b/ChessCoachTests/Services/LLMServiceTests.swift
@@ -23,7 +23,8 @@ import Testing
         matchedResponseAdjustment: nil,
         coachPersonalityPrompt: nil,
         opening: nil,
-        bookStatus: nil
+        bookStatus: nil,
+        deviationCategory: nil
     )
     let prompt = LLMService.buildPrompt(for: context)
     #expect(prompt.contains("e2e4"))
@@ -52,7 +53,8 @@ import Testing
         matchedResponseAdjustment: nil,
         coachPersonalityPrompt: nil,
         opening: nil,
-        bookStatus: nil
+        bookStatus: nil,
+        deviationCategory: nil
     )
     let result = LLMService.buildPrompt(for: context)
     #expect(result.contains("correct"))
@@ -80,7 +82,8 @@ import Testing
         matchedResponseAdjustment: nil,
         coachPersonalityPrompt: nil,
         opening: nil,
-        bookStatus: nil
+        bookStatus: nil,
+        deviationCategory: nil
     )
     let prompt = LLMService.buildPrompt(for: context)
     #expect(prompt.contains("e2e4"))

--- a/ChessCoachTests/Services/OffBookCoachingServiceTests.swift
+++ b/ChessCoachTests/Services/OffBookCoachingServiceTests.swift
@@ -1,0 +1,155 @@
+import Testing
+@testable import ChessCoach
+
+@Suite
+struct OffBookCoachingServiceTests {
+    let service = OffBookCoachingService()
+    let db = OpeningDatabase()
+
+    // MARK: - guidanceIncludesPlanSummary
+
+    @Test func guidanceIncludesPlanSummary() {
+        let italian = db.opening(named: "Italian Game")!
+        // FEN after 1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 — then player deviates at ply 6
+        let fen = "r1bqk1nr/pppp1ppp/2n5/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4"
+        let guidance = service.generateGuidance(
+            fen: fen,
+            opening: italian,
+            deviationPly: 6,
+            moveHistory: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5"]
+        )
+
+        #expect(!guidance.summary.isEmpty)
+        #expect(guidance.summary.contains("Italian Game"))
+        #expect(guidance.summary.contains("4")) // move number = (6/2)+1 = 4
+        #expect(!guidance.planReminder.isEmpty)
+        // The plan reminder should be the opening's plan summary
+        #expect(guidance.planReminder == italian.plan!.summary)
+    }
+
+    // MARK: - guidanceForOpponentDeviation
+
+    @Test func guidanceForOpponentDeviation() {
+        let italian = db.opening(named: "Italian Game")!
+        let fen = "r1bqk1nr/pppp1ppp/2n5/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4"
+        let guidance = service.generateGuidance(
+            fen: fen,
+            opening: italian,
+            deviationPly: 5,
+            moveHistory: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bb4"],
+            opponentDeviation: (played: "Bb4", expected: "Bc5")
+        )
+
+        #expect(guidance.summary.contains("opponent"))
+        #expect(guidance.summary.contains("Bb4"))
+        #expect(guidance.summary.contains("Bc5"))
+    }
+
+    // MARK: - relevantGoalsFiltersByCheckCondition
+
+    @Test func relevantGoalsFiltersByCheckCondition() {
+        // Create a synthetic opening with checkCondition on a goal
+        let goalMet = StrategicGoal(
+            description: "Put bishop on a2-g8 diagonal",
+            priority: 1,
+            measurable: true,
+            checkCondition: "bishop_on_diagonal_a2g8"
+        )
+        let goalUnmet = StrategicGoal(
+            description: "Castle kingside",
+            priority: 2,
+            measurable: true,
+            checkCondition: "castled_kingside"
+        )
+        let plan = OpeningPlan(
+            summary: "Test plan",
+            strategicGoals: [goalMet, goalUnmet],
+            pawnStructureTarget: "e4/d3",
+            keySquares: ["f7"],
+            pieceTargets: [],
+            typicalPlans: [],
+            commonMistakes: [],
+            historicalNote: nil,
+            planLessons: nil,
+            theoryLessons: nil,
+            planQuizzes: nil,
+            theoryQuizzes: nil
+        )
+
+        var opening = Opening(
+            id: "test",
+            name: "Test Opening",
+            description: "A test",
+            color: .white,
+            difficulty: 1,
+            tags: nil,
+            mainLine: []
+        )
+        opening.plan = plan
+
+        // FEN with white bishop on c4 (a2-g8 diagonal) and castling rights still present
+        let fen = "r1bqk1nr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4"
+
+        let guidance = service.generateGuidance(
+            fen: fen,
+            opening: opening,
+            deviationPly: 6,
+            moveHistory: []
+        )
+
+        // The bishop IS on diagonal a2g8 (c4), so that goal should be FILTERED OUT (met)
+        // Castling rights are still present (KQkq), so castled_kingside is NOT met — goal stays
+        let goalDescriptions = guidance.relevantGoals.map(\.description)
+        #expect(!goalDescriptions.contains("Put bishop on a2-g8 diagonal"))
+        #expect(goalDescriptions.contains("Castle kingside"))
+    }
+
+    // MARK: - FEN Parser unit tests
+
+    @Test func isPieceOnSquareFindsWhiteBishopOnC4() {
+        let board = "r1bqk1nr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R"
+        #expect(FENParser.isPieceOnSquare(piece: "B", square: "c4", board: board))
+        #expect(!FENParser.isPieceOnSquare(piece: "B", square: "d4", board: board))
+    }
+
+    @Test func squaresOnDiagonalA2G8() {
+        let squares = FENParser.squaresOnDiagonal("a2g8")
+        #expect(squares == ["a2", "b3", "c4", "d5", "e6", "f7", "g8"])
+    }
+
+    @Test func isCastledDetectsRightsPresent() {
+        let fen = "r1bqk1nr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4"
+        // Castling rights present → not yet castled
+        #expect(!FENParser.isCastled(kingside: true, fen: fen, isWhite: true))
+    }
+
+    @Test func isCastledDetectsRightsGone() {
+        // White has lost kingside castling rights (only Qq remain)
+        let fen = "r1bqk1nr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w Qq - 4 4"
+        #expect(FENParser.isCastled(kingside: true, fen: fen, isWhite: true))
+    }
+
+    @Test func genericGuidanceWhenNoPlan() {
+        var opening = Opening(
+            id: "test-no-plan",
+            name: "Mystery Opening",
+            description: "No plan",
+            color: .white,
+            difficulty: 1,
+            tags: nil,
+            mainLine: []
+        )
+        opening.plan = nil
+
+        let guidance = service.generateGuidance(
+            fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+            opening: opening,
+            deviationPly: 2,
+            moveHistory: ["e4"]
+        )
+
+        #expect(guidance.summary.contains("Mystery Opening"))
+        #expect(!guidance.planReminder.isEmpty)
+        #expect(guidance.relevantGoals.isEmpty)
+    }
+}

--- a/ChessCoachTests/Services/OffBookCoachingServiceTests.swift
+++ b/ChessCoachTests/Services/OffBookCoachingServiceTests.swift
@@ -152,4 +152,78 @@ struct OffBookCoachingServiceTests {
         #expect(!guidance.planReminder.isEmpty)
         #expect(guidance.relevantGoals.isEmpty)
     }
+
+    // MARK: - Deviation Classification
+
+    @Test func classifiesTempoWaste() {
+        let fen = "rnbqkbnr/pppp1ppp/8/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3"
+        let moveHistory: [(from: String, to: String)] = [
+            (from: "e2", to: "e4"), (from: "b8", to: "c6"),
+            (from: "g1", to: "f3"), (from: "c6", to: "b8"),
+            (from: "f1", to: "c4"), (from: "e7", to: "e5"),
+        ]
+        let category = OffBookCoachingService.classifyDeviation(
+            fen: fen, moveHistory: moveHistory, playerIsWhite: true
+        )
+        #expect(category == .tempoWaste)
+    }
+
+    @Test func classifiesCenterConcession() {
+        let fen = "rnbqkb1r/pppp1ppp/5n2/8/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 4 4"
+        let moveHistory: [(from: String, to: String)] = [
+            (from: "e2", to: "e4"), (from: "g8", to: "f6"),
+            (from: "g1", to: "f3"), (from: "a7", to: "a6"),
+            (from: "f1", to: "c4"), (from: "h7", to: "h6"),
+            (from: "d2", to: "d4"), (from: "b7", to: "b6"),
+        ]
+        let category = OffBookCoachingService.classifyDeviation(
+            fen: fen, moveHistory: moveHistory, playerIsWhite: true
+        )
+        #expect(category == .centerConcession)
+    }
+
+    @Test func classifiesDelayedDevelopment() {
+        // Black has e-pawn on e5 (not center-conceded) but 3 minor pieces still home (Nb8, Bc8, Bf8)
+        let fen = "rnbqkb1r/pppp1ppp/5n2/4p3/2BPP3/5N2/PPP2PPP/RNBQK2R b KQkq - 0 4"
+        let moveHistory: [(from: String, to: String)] = [
+            (from: "e2", to: "e4"), (from: "e7", to: "e5"),
+            (from: "g1", to: "f3"), (from: "g8", to: "f6"),
+            (from: "f1", to: "c4"), (from: "a7", to: "a6"),
+            (from: "d2", to: "d4"), (from: "h7", to: "h6"),
+        ]
+        let category = OffBookCoachingService.classifyDeviation(
+            fen: fen, moveHistory: moveHistory, playerIsWhite: true
+        )
+        #expect(category == .delayedDevelopment)
+    }
+
+    @Test func classifiesDelayedCastling() {
+        let fen = "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/3P1N2/PPP2PPP/RNBQ1RK1 b kq - 0 6"
+        let moveHistory: [(from: String, to: String)] = [
+            (from: "e2", to: "e4"), (from: "e7", to: "e5"),
+            (from: "g1", to: "f3"), (from: "b8", to: "c6"),
+            (from: "f1", to: "c4"), (from: "f8", to: "c5"),
+            (from: "d2", to: "d3"), (from: "g8", to: "f6"),
+            (from: "e1", to: "g1"), (from: "d7", to: "d6"),
+            (from: "c1", to: "e3"), (from: "a7", to: "a6"),
+            (from: "b1", to: "d2"), (from: "h7", to: "h6"),
+        ]
+        let category = OffBookCoachingService.classifyDeviation(
+            fen: fen, moveHistory: moveHistory, playerIsWhite: true
+        )
+        #expect(category == .delayedCastling)
+    }
+
+    @Test func classifiesUnclassifiedWhenNoPatternMatches() {
+        let fen = "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4"
+        let moveHistory: [(from: String, to: String)] = [
+            (from: "e2", to: "e4"), (from: "e7", to: "e5"),
+            (from: "g1", to: "f3"), (from: "b8", to: "c6"),
+            (from: "f1", to: "c4"), (from: "f8", to: "c5"),
+        ]
+        let category = OffBookCoachingService.classifyDeviation(
+            fen: fen, moveHistory: moveHistory, playerIsWhite: true
+        )
+        #expect(category == .unclassified)
+    }
 }

--- a/ChessCoachTests/Services/OffBookCoachingServiceTests.swift
+++ b/ChessCoachTests/Services/OffBookCoachingServiceTests.swift
@@ -16,12 +16,10 @@ struct OffBookCoachingServiceTests {
             fen: fen,
             opening: italian,
             deviationPly: 6,
-            moveHistory: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5"]
+            moveHistory: [("e2","e4"), ("e7","e5"), ("g1","f3"), ("b8","c6"), ("f1","c4"), ("f8","c5")]
         )
 
-        #expect(!guidance.summary.isEmpty)
-        #expect(guidance.summary.contains("Italian Game"))
-        #expect(guidance.summary.contains("4")) // move number = (6/2)+1 = 4
+        #expect(guidance.category == .unclassified)
         #expect(!guidance.planReminder.isEmpty)
         // The plan reminder should be the opening's plan summary
         #expect(guidance.planReminder == italian.plan!.summary)
@@ -36,13 +34,10 @@ struct OffBookCoachingServiceTests {
             fen: fen,
             opening: italian,
             deviationPly: 5,
-            moveHistory: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bb4"],
-            opponentDeviation: (played: "Bb4", expected: "Bc5")
+            moveHistory: [("e2","e4"), ("e7","e5"), ("g1","f3"), ("b8","c6"), ("f1","c4"), ("f8","b4")]
         )
 
-        #expect(guidance.summary.contains("opponent"))
-        #expect(guidance.summary.contains("Bb4"))
-        #expect(guidance.summary.contains("Bc5"))
+        #expect(guidance.category == .unclassified)
     }
 
     // MARK: - relevantGoalsFiltersByCheckCondition
@@ -94,7 +89,7 @@ struct OffBookCoachingServiceTests {
             fen: fen,
             opening: opening,
             deviationPly: 6,
-            moveHistory: []
+            moveHistory: [] as [(from: String, to: String)]
         )
 
         // The bishop IS on diagonal a2g8 (c4), so that goal should be FILTERED OUT (met)
@@ -145,10 +140,10 @@ struct OffBookCoachingServiceTests {
             fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
             opening: opening,
             deviationPly: 2,
-            moveHistory: ["e4"]
+            moveHistory: [("e2","e4")]
         )
 
-        #expect(guidance.summary.contains("Mystery Opening"))
+        #expect(guidance.category == .unclassified)
         #expect(!guidance.planReminder.isEmpty)
         #expect(guidance.relevantGoals.isEmpty)
     }

--- a/ChessCoachTests/Views/CoachingTierBadgeTests.swift
+++ b/ChessCoachTests/Views/CoachingTierBadgeTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import ChessCoach
+
+@Suite
+struct CoachingTierBadgeTests {
+    @Test func basicBadgeShowsCorrectText() {
+        let badge = CoachingTierBadge(isLLM: false)
+        #expect(badge.label == "Basic")
+    }
+
+    @Test func aiCoachBadgeShowsCorrectText() {
+        let badge = CoachingTierBadge(isLLM: true)
+        #expect(badge.label == "AI Coach")
+    }
+}

--- a/ChessCoachTests/Views/OpeningIndicatorBannerTests.swift
+++ b/ChessCoachTests/Views/OpeningIndicatorBannerTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import ChessCoach
+
+@Suite
+struct OpeningIndicatorBannerTests {
+    @Test func detectsItalianAfterMoves() {
+        let detector = HolisticDetector()
+        let detection = detector.detect(moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4"])
+        #expect(detection.whiteFramework.primary != nil)
+        let name = detection.whiteFramework.primary?.opening.name ?? ""
+        #expect(name.lowercased().contains("italian"))
+    }
+
+    @Test func bothSidesDetected() {
+        let detector = HolisticDetector()
+        let detection = detector.detect(moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4", "f8c5"])
+        #expect(detection.whiteFramework.primary != nil)
+        #expect(detection.blackFramework.primary != nil)
+    }
+}

--- a/docs/plans/2026-03-04-deviation-coaching-design.md
+++ b/docs/plans/2026-03-04-deviation-coaching-design.md
@@ -1,0 +1,72 @@
+# Deviation Coaching Redesign
+
+## Problem
+
+The current off-book coaching tells users "You/Your opponent left the Italian Game at move 5." This framing is wrong:
+
+1. It treats any deviation from the memorized sequence as "leaving" the opening
+2. It doesn't distinguish between a known alternative (Two Knights Defense) and a blunder (3...h6)
+3. It doesn't help the user understand *why* the opponent's move is weak or how to exploit it
+4. It frames deviations as problems when they're often opportunities
+
+The purpose of learning openings isn't memorizing exact sequences — it's understanding the *plan*. When an opponent plays something suboptimal, the plan usually gets easier, not harder. Coaching should communicate this.
+
+## Design
+
+### Deviation Classification
+
+When the opponent deviates, classify their move using FEN-based heuristics:
+
+| Category | Detection | Free-tier template |
+|----------|-----------|-------------------|
+| **Tempo waste** | Same piece moved twice in first 10 moves (track from/to in moveHistory) | "Your opponent moved the same piece twice. Keep developing — you have a tempo advantage." |
+| **Center concession** | Opponent has no pawns on d4/d5/e4/e5 by ply 8+ | "Your opponent hasn't contested the center. Your central control gives you the initiative." |
+| **Delayed development** | 3+ opponent minor pieces still on back rank after ply 8+ | "Your opponent is behind in development. Keep developing and look for opportunities to open the position." |
+| **Delayed castling** | Opponent hasn't castled by ply 14+ (castling rights present + king on original square) | "Your opponent hasn't castled yet. Consider opening the center to exploit their exposed king." |
+| **Known alternative** | Holistic detector identifies a different named opening for opponent's side | No coaching — the OpeningIndicatorBanner already shows what they're playing |
+| **Unclassified** | None of the above | Plan reminder + unmet piece targets (existing behavior) |
+
+These are intentionally simple heuristics targeting common beginner mistakes (600-1200 ELO). They catch the most frequent "stupid" moves without requiring Stockfish.
+
+### Coaching Tiers
+
+| Tier | Coaching quality | Badge |
+|------|-----------------|-------|
+| **Free** | Deviation category template + plan reminder + unmet piece targets | "Basic" |
+| **Pro (LLM)** | Full contextual coaching — why the move is weak, how to exploit it, tailored to ELO | "AI Coach" |
+
+The current `FeatureAccess.isUnlocked(.llmCoaching)` gates the tier. This will be rewired when the 4-tier entitlement model is built (Free / A la carte / Enthusiast / Power User).
+
+### Coaching UI Additions
+
+**CoachingTierBadge** — small label on every coaching feed entry. "Basic" for free tier, "AI Coach" for LLM tier. Uses `AppColor.secondaryText` styling, doesn't dominate the UI.
+
+**CoachingUpgradeCTA** — tappable prompt shown below coaching text: "Unlock deeper analysis". Appears:
+- After the first deviation in a session
+- After mistakes
+- Maximum once per session to avoid annoyance
+
+Links to existing paywall sheet.
+
+### LLM Context Enhancement
+
+For pro users, pass the `DeviationCategory` into `CoachingContext` so the LLM prompt can give targeted advice. Instead of "opponent deviated from the main line," the prompt says "opponent wasted a tempo by moving the same piece twice" — letting the LLM explain how to exploit it specifically.
+
+### Architecture
+
+**`DeviationCategory` enum** — Sendable, lives in OffBookCoachingService.swift. Each case has a `templateMessage` computed property for free-tier coaching.
+
+**`OffBookCoachingService.classifyDeviation()`** — Pure function. Takes FEN, move history, player color. Returns `DeviationCategory`. Uses ChessKit `enumeratedPieces()` for piece positions, move history for tempo tracking.
+
+**`OffBookGuidance.category`** — New field. `generateGuidance()` calls `classifyDeviation()` and includes the result.
+
+**`CoachingContext.deviationCategory`** — New optional field. Prompt template uses it for LLM framing.
+
+**`CoachingTierBadge`** — SwiftUI view, shown on feed entries.
+
+**`CoachingUpgradeCTA`** — SwiftUI view, tappable, links to paywall. Gated by session state.
+
+### What Gets Removed
+
+- `buildSummary()` and all "left the opening" / "You left the X at move Y" messaging
+- The `summary` field in `OffBookGuidance` is replaced by category-driven messaging

--- a/docs/plans/2026-03-04-deviation-coaching-plan.md
+++ b/docs/plans/2026-03-04-deviation-coaching-plan.md
@@ -1,0 +1,711 @@
+# Deviation Coaching Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace "left the opening" messaging with deviation classification (tempo waste, center concession, etc.) and add coaching tier badges + upgrade CTAs.
+
+**Architecture:** Add a `DeviationCategory` enum and `classifyDeviation()` to `OffBookCoachingService`. Replace `buildSummary()` with category-driven templates. Add `CoachingTierBadge` and `CoachingUpgradeCTA` SwiftUI views to the feed. Pass category to LLM via `CoachingContext`.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing, ChessKit (for `enumeratedPieces()`), XcodeGen
+
+---
+
+### Task 1: Add `DeviationCategory` enum and classification tests
+
+**Files:**
+- Modify: `ChessCoach/Services/OffBookCoachingService.swift:1-13` (add enum before `OffBookGuidance`)
+- Test: `ChessCoachTests/Services/OffBookCoachingServiceTests.swift`
+
+**Step 1: Write failing tests**
+
+Add these tests to the existing `OffBookCoachingServiceTests` suite in `ChessCoachTests/Services/OffBookCoachingServiceTests.swift`:
+
+```swift
+// MARK: - Deviation Classification
+
+@Test func classifiesTempoWaste() {
+    // Opponent moved knight to c6 then back to b8 — same piece twice
+    let fen = "rnbqkbnr/pppp1ppp/8/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3"
+    let moveHistory: [(from: String, to: String)] = [
+        (from: "e2", to: "e4"), (from: "b8", to: "c6"),
+        (from: "g1", to: "f3"), (from: "c6", to: "b8"),  // opponent moved knight back
+        (from: "f1", to: "c4"), (from: "e7", to: "e5"),
+    ]
+    let category = OffBookCoachingService.classifyDeviation(
+        fen: fen, moveHistory: moveHistory, playerIsWhite: true
+    )
+    #expect(category == .tempoWaste)
+}
+
+@Test func classifiesCenterConcession() {
+    // After ply 8, opponent has no center pawns (d4/d5/e4/e5)
+    // White has e4, black has nothing on d5/e5/d4/e4
+    let fen = "rnbqkb1r/pppp1ppp/5n2/8/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 4 4"
+    let moveHistory: [(from: String, to: String)] = [
+        (from: "e2", to: "e4"), (from: "g8", to: "f6"),
+        (from: "g1", to: "f3"), (from: "a7", to: "a6"),
+        (from: "f1", to: "c4"), (from: "h7", to: "h6"),
+        (from: "d2", to: "d4"), (from: "b7", to: "b6"),
+    ]
+    let category = OffBookCoachingService.classifyDeviation(
+        fen: fen, moveHistory: moveHistory, playerIsWhite: true
+    )
+    #expect(category == .centerConcession)
+}
+
+@Test func classifiesDelayedDevelopment() {
+    // After ply 8+, opponent still has 3+ minor pieces on back rank
+    // Black has bishop on c8, bishop on f8, knight on b8 still home
+    let fen = "rnbqkb1r/pppppppp/5n2/8/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 4 4"
+    let moveHistory: [(from: String, to: String)] = [
+        (from: "e2", to: "e4"), (from: "g8", to: "f6"),
+        (from: "g1", to: "f3"), (from: "e7", to: "e6"),
+        (from: "f1", to: "c4"), (from: "d7", to: "d6"),
+        (from: "d2", to: "d4"), (from: "a7", to: "a6"),
+    ]
+    let category = OffBookCoachingService.classifyDeviation(
+        fen: fen, moveHistory: moveHistory, playerIsWhite: true
+    )
+    #expect(category == .delayedDevelopment)
+}
+
+@Test func classifiesDelayedCastling() {
+    // After ply 14+, opponent still has castling rights and king on original square
+    let fen = "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/3P1N2/PPP2PPP/RNBQ1RK1 b kq - 0 6"
+    let moveHistory: [(from: String, to: String)] = [
+        (from: "e2", to: "e4"), (from: "e7", to: "e5"),
+        (from: "g1", to: "f3"), (from: "b8", to: "c6"),
+        (from: "f1", to: "c4"), (from: "f8", to: "c5"),
+        (from: "d2", to: "d3"), (from: "g8", to: "f6"),
+        (from: "e1", to: "g1"), (from: "d7", to: "d6"),
+        (from: "c1", to: "e3"), (from: "a7", to: "a6"),
+        (from: "b1", to: "d2"), (from: "h7", to: "h6"),
+    ]
+    let category = OffBookCoachingService.classifyDeviation(
+        fen: fen, moveHistory: moveHistory, playerIsWhite: true
+    )
+    #expect(category == .delayedCastling)
+}
+
+@Test func classifiesUnclassifiedWhenNoPatternMatches() {
+    // Normal-looking position, no obvious issues
+    let fen = "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4"
+    let moveHistory: [(from: String, to: String)] = [
+        (from: "e2", to: "e4"), (from: "e7", to: "e5"),
+        (from: "g1", to: "f3"), (from: "b8", to: "c6"),
+        (from: "f1", to: "c4"), (from: "f8", to: "c5"),
+    ]
+    let category = OffBookCoachingService.classifyDeviation(
+        fen: fen, moveHistory: moveHistory, playerIsWhite: true
+    )
+    #expect(category == .unclassified)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5`
+Expected: FAIL — `DeviationCategory` and `classifyDeviation` don't exist yet
+
+**Step 3: Add `DeviationCategory` enum**
+
+In `ChessCoach/Services/OffBookCoachingService.swift`, add **before** the `OffBookGuidance` struct (line 1):
+
+```swift
+/// Classification of how an opponent deviated from book theory.
+enum DeviationCategory: Sendable, Equatable {
+    case tempoWaste
+    case centerConcession
+    case delayedDevelopment
+    case delayedCastling
+    case knownAlternative(name: String)
+    case unclassified
+
+    /// Free-tier coaching template for this deviation type.
+    var templateMessage: String {
+        switch self {
+        case .tempoWaste:
+            return "Your opponent moved the same piece twice. Keep developing — you have a tempo advantage."
+        case .centerConcession:
+            return "Your opponent hasn't contested the center. Your central control gives you the initiative."
+        case .delayedDevelopment:
+            return "Your opponent is behind in development. Keep developing and look for opportunities to open the position."
+        case .delayedCastling:
+            return "Your opponent hasn't castled yet. Consider opening the center to exploit their exposed king."
+        case .knownAlternative(let name):
+            return "Your opponent is playing the \(name)."
+        case .unclassified:
+            return "Your opponent played a move outside of book theory."
+        }
+    }
+}
+```
+
+**Step 4: Add `classifyDeviation()` static method**
+
+Add to `OffBookCoachingService` struct (after `pieceChar` at line 168):
+
+```swift
+/// Classify an opponent's deviation from book using positional heuristics.
+///
+/// Checks (in priority order): tempo waste, center concession, delayed development,
+/// delayed castling. Returns `.unclassified` if no pattern matches.
+///
+/// - Parameters:
+///   - fen: Current board position
+///   - moveHistory: All moves played so far as (from, to) pairs
+///   - playerIsWhite: Whether the student is playing white
+static func classifyDeviation(
+    fen: String,
+    moveHistory: [(from: String, to: String)],
+    playerIsWhite: Bool
+) -> DeviationCategory {
+    let board = FENParser.boardString(from: fen)
+    let plyCount = moveHistory.count
+    let opponentIsWhite = !playerIsWhite
+
+    // 1. Tempo waste: opponent moved a piece from square A to B, then later from B back to A
+    //    (or moved from the same origin square twice) within the first 10 moves
+    let opponentMoves = moveHistory.enumerated()
+        .filter { opponentIsWhite ? $0.offset % 2 == 0 : $0.offset % 2 == 1 }
+        .map { $0.element }
+
+    for i in 0..<opponentMoves.count {
+        for j in (i+1)..<opponentMoves.count {
+            // Piece went A→B then B→A (moved back)
+            if opponentMoves[i].to == opponentMoves[j].from &&
+               opponentMoves[i].from == opponentMoves[j].to {
+                return .tempoWaste
+            }
+            // Same piece moved twice (from same origin — piece was already there)
+            if opponentMoves[i].from == opponentMoves[j].from {
+                return .tempoWaste
+            }
+        }
+    }
+
+    // 2. Center concession: opponent has no pawns on central squares after ply 8
+    if plyCount >= 8 {
+        let opponentPawn: Character = opponentIsWhite ? "P" : "p"
+        let centerSquares = ["d4", "d5", "e4", "e5"]
+        let hasCenterPawn = centerSquares.contains { square in
+            FENParser.isPieceOnSquare(piece: opponentPawn, square: square, board: board)
+        }
+        if !hasCenterPawn {
+            return .centerConcession
+        }
+    }
+
+    // 3. Delayed development: 3+ opponent minor pieces still on back rank after ply 8
+    if plyCount >= 8 {
+        let backRank = opponentIsWhite ? 1 : 8
+        let minorPieceTypes: [(Character, [String])] = opponentIsWhite
+            ? [("N", ["b1", "g1"]), ("B", ["c1", "f1"])]
+            : [("n", ["b8", "g8"]), ("b", ["c8", "f8"])]
+
+        var homeCount = 0
+        for (piece, homeSquares) in minorPieceTypes {
+            for square in homeSquares {
+                if FENParser.isPieceOnSquare(piece: piece, square: square, board: board) {
+                    homeCount += 1
+                }
+            }
+        }
+        if homeCount >= 3 {
+            return .delayedDevelopment
+        }
+    }
+
+    // 4. Delayed castling: opponent hasn't castled by ply 14
+    if plyCount >= 14 {
+        let hasCastled = FENParser.isCastled(kingside: true, fen: fen, isWhite: opponentIsWhite)
+            || FENParser.isCastled(kingside: false, fen: fen, isWhite: opponentIsWhite)
+        if !hasCastled {
+            return .delayedCastling
+        }
+    }
+
+    return .unclassified
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add ChessCoach/Services/OffBookCoachingService.swift ChessCoachTests/Services/OffBookCoachingServiceTests.swift
+git commit -m "feat: add DeviationCategory enum and classifyDeviation heuristics with tests"
+```
+
+---
+
+### Task 2: Wire `DeviationCategory` into `OffBookGuidance` and replace `buildSummary()`
+
+**Files:**
+- Modify: `ChessCoach/Services/OffBookCoachingService.swift:4-13,31-85,90-115`
+- Test: `ChessCoachTests/Services/OffBookCoachingServiceTests.swift`
+
+**Step 1: Update `OffBookGuidance` struct**
+
+Replace the `OffBookGuidance` struct (lines 4-13) with:
+
+```swift
+/// Guidance generated when a game goes off-book (deviates from known opening theory).
+struct OffBookGuidance: Sendable {
+    /// Classification of the deviation type
+    let category: DeviationCategory
+    /// Plan reminder from the opening's strategic plan
+    let planReminder: String
+    /// Actionable suggestion based on unmet piece targets or strategic goals
+    let suggestion: String?
+    /// Strategic goals that are still relevant given the current position
+    let relevantGoals: [StrategicGoal]
+
+    /// Category-driven coaching message for free-tier users.
+    var templateCoaching: String {
+        var text = category.templateMessage
+        if !planReminder.isEmpty {
+            text += " \(planReminder)"
+        }
+        if let suggestion {
+            text += " \(suggestion)"
+        }
+        return text
+    }
+}
+```
+
+**Step 2: Update `generateGuidance()` signature and body**
+
+Replace the `generateGuidance()` function (lines 31-85) — add `moveHistory` type change to accept tuples, call `classifyDeviation()`, remove `buildSummary()`:
+
+```swift
+func generateGuidance(
+    fen: String,
+    opening: Opening,
+    deviationPly: Int,
+    moveHistory: [(from: String, to: String)],
+    opponentDeviation: (played: String, expected: String)? = nil
+) -> OffBookGuidance {
+    let isWhite = opening.color == .white
+
+    // Classify the deviation
+    let category: DeviationCategory = Self.classifyDeviation(
+        fen: fen, moveHistory: moveHistory, playerIsWhite: isWhite
+    )
+
+    guard let plan = opening.plan else {
+        return OffBookGuidance(
+            category: category,
+            planReminder: "Keep developing your pieces toward the center and castle early.",
+            suggestion: "Focus on getting your knights and bishops out before moving the same piece twice.",
+            relevantGoals: []
+        )
+    }
+
+    let board = FENParser.boardString(from: fen)
+
+    // 1. Filter strategic goals to those still relevant
+    let relevantGoals = plan.strategicGoals.filter { goal in
+        guard let condition = goal.checkCondition else { return true }
+        return !isConditionMet(condition, board: board, fen: fen, isWhite: isWhite)
+    }.sorted { $0.priority < $1.priority }
+
+    // 2. Find unmet piece targets
+    let unmetTargets = plan.pieceTargets.filter { target in
+        let pieceChar = Self.pieceChar(name: target.piece, isWhite: isWhite)
+        return !target.idealSquares.contains { square in
+            FENParser.isPieceOnSquare(piece: pieceChar, square: square, board: board)
+        }
+    }
+
+    // 3. Build suggestion from unmet targets or top relevant goal
+    let suggestion: String?
+    if let firstUnmet = unmetTargets.first {
+        let squares = firstUnmet.idealSquares.joined(separator: " or ")
+        suggestion = "Consider developing your \(firstUnmet.piece) to \(squares) — \(firstUnmet.reasoning.lowercasedFirst)"
+    } else if let topGoal = relevantGoals.first {
+        suggestion = topGoal.description
+    } else {
+        suggestion = nil
+    }
+
+    return OffBookGuidance(
+        category: category,
+        planReminder: plan.summary,
+        suggestion: suggestion,
+        relevantGoals: relevantGoals
+    )
+}
+```
+
+**Step 3: Delete `buildSummary()` and `genericGuidance()` methods**
+
+Delete lines 89-115 (the `genericGuidance` and `buildSummary` methods) — their logic is now in `DeviationCategory.templateMessage` and the updated `generateGuidance()`.
+
+**Step 4: Update all `generateGuidance()` call sites**
+
+The `moveHistory` parameter type changed from `[String]` to `[(from: String, to: String)]`. Update callers:
+
+In `CoachingService.swift` `freeCoaching()` (line 340-345):
+```swift
+let guidance = offBookService.generateGuidance(
+    fen: context.fen,
+    opening: opening,
+    deviationPly: p,
+    moveHistory: [],  // Still empty — CoachingContext has String moveHistory, not tuples
+    opponentDeviation: opponentDev
+)
+```
+The empty array `[]` is type-compatible with `[(from: String, to: String)]`.
+
+In `GamePlayViewModel+Session.swift` `showOffBookGuidance()` (~line 691):
+```swift
+let guidance = offBookCoachingService.generateGuidance(
+    fen: gameState.fen,
+    opening: opening,
+    deviationPly: deviationPly,
+    moveHistory: gameState.moveHistory.map { (from: $0.from, to: $0.to) },
+    opponentDeviation: opponentDev
+)
+```
+
+**Step 5: Update callers to use `guidance.templateCoaching` instead of manual string building**
+
+In `CoachingService.swift` `freeCoaching()`, replace the manual text building:
+```swift
+// OLD:
+var text = guidance.summary
+if !guidance.planReminder.isEmpty { text += " \(guidance.planReminder)" }
+if let suggestion = guidance.suggestion { text += " \(suggestion)" }
+return text
+
+// NEW:
+return guidance.templateCoaching
+```
+
+In `GamePlayViewModel+Session.swift` `showOffBookGuidance()`:
+```swift
+// OLD:
+var text = guidance.summary
+if !guidance.planReminder.isEmpty { text += " \(guidance.planReminder)" }
+if let suggestion = guidance.suggestion { text += " \(suggestion)" }
+userCoachingText = text
+
+// NEW:
+userCoachingText = guidance.templateCoaching
+```
+
+**Step 6: Update tests**
+
+Update existing tests in `OffBookCoachingServiceTests.swift`:
+
+- `guidanceIncludesPlanSummary`: Remove `#expect(guidance.summary.contains("Italian Game"))` and `#expect(guidance.summary.contains("4"))`. Replace with `#expect(guidance.category != .knownAlternative(name: ""))`. Keep planReminder assertion.
+- `guidanceForOpponentDeviation`: Remove assertions about `summary` containing "opponent"/"Bb4"/"Bc5". Replace with `#expect(guidance.category == .unclassified)` (short move history, no heuristic triggers). Keep planReminder.
+- `genericGuidanceWhenNoPlan`: Remove `#expect(guidance.summary.contains("Mystery Opening"))`. Replace with `#expect(guidance.category == .unclassified)`. Keep planReminder/relevantGoals assertions.
+
+**Step 7: Run tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5`
+Expected: PASS
+
+**Step 8: Commit**
+
+```bash
+git add ChessCoach/Services/OffBookCoachingService.swift ChessCoach/Services/CoachingService/CoachingService.swift ChessCoach/ViewModels/GamePlayViewModel+Session.swift ChessCoachTests/Services/OffBookCoachingServiceTests.swift
+git commit -m "feat: replace 'left the opening' messaging with deviation category templates"
+```
+
+---
+
+### Task 3: Add `CoachingTierBadge` view
+
+**Files:**
+- Create: `ChessCoach/Components/Feed/CoachingTierBadge.swift`
+- Modify: `ChessCoach/Components/Feed/FeedRowCard.swift:136-155`
+- Test: `ChessCoachTests/Views/CoachingTierBadgeTests.swift`
+
+**Step 1: Write failing test**
+
+Create `ChessCoachTests/Views/CoachingTierBadgeTests.swift`:
+
+```swift
+import Testing
+@testable import ChessCoach
+
+@Suite
+struct CoachingTierBadgeTests {
+    @Test func basicBadgeShowsCorrectText() {
+        let badge = CoachingTierBadge(isLLM: false)
+        #expect(badge.label == "Basic")
+    }
+
+    @Test func aiCoachBadgeShowsCorrectText() {
+        let badge = CoachingTierBadge(isLLM: true)
+        #expect(badge.label == "AI Coach")
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5`
+Expected: FAIL — `CoachingTierBadge` doesn't exist
+
+**Step 3: Create `CoachingTierBadge`**
+
+Create `ChessCoach/Components/Feed/CoachingTierBadge.swift`:
+
+```swift
+import SwiftUI
+
+/// Small badge indicating the coaching analysis tier: "Basic" or "AI Coach".
+struct CoachingTierBadge: View {
+    let isLLM: Bool
+
+    var label: String { isLLM ? "AI Coach" : "Basic" }
+
+    private var color: Color { isLLM ? AppColor.info : AppColor.tertiaryText }
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12), in: Capsule())
+            .accessibilityLabel("\(label) analysis")
+    }
+}
+```
+
+**Step 4: Add badge to `FeedRowCard`**
+
+In `ChessCoach/Components/Feed/FeedRowCard.swift`, find the `categoryBadge` view (around line 136). Add a `coachingTierBadge` next to it. The feed entry needs a new `isLLMCoaching: Bool` field — or we can infer it from whether coaching text exists and feature access. For now, add it to `FeedEntry`:
+
+In the file where `FeedEntry` is defined (look for `struct FeedEntry`), add:
+```swift
+var isLLMCoaching: Bool = false
+```
+
+Then in `FeedRowCard`, after the `categoryBadge` call, add the tier badge when coaching text is present:
+
+```swift
+if entry.coaching != nil {
+    CoachingTierBadge(isLLM: entry.isLLMCoaching)
+}
+```
+
+**Step 5: Run tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add ChessCoach/Components/Feed/CoachingTierBadge.swift ChessCoach/Components/Feed/FeedRowCard.swift ChessCoachTests/Views/CoachingTierBadgeTests.swift
+git commit -m "feat: add CoachingTierBadge showing Basic/AI Coach on feed entries"
+```
+
+---
+
+### Task 4: Add `CoachingUpgradeCTA` view
+
+**Files:**
+- Create: `ChessCoach/Components/Feed/CoachingUpgradeCTA.swift`
+- Modify: `ChessCoach/ViewModels/GamePlayViewModel+Session.swift` (track CTA shown state)
+
+**Step 1: Create `CoachingUpgradeCTA`**
+
+Create `ChessCoach/Components/Feed/CoachingUpgradeCTA.swift`:
+
+```swift
+import SwiftUI
+
+/// Tappable prompt encouraging free-tier users to upgrade for deeper coaching analysis.
+/// Appears after first deviation or mistake in a session, maximum once per session.
+struct CoachingUpgradeCTA: View {
+    @State private var showPaywall = false
+
+    var body: some View {
+        Button {
+            showPaywall = true
+        } label: {
+            HStack(spacing: AppSpacing.sm) {
+                Image(systemName: "sparkles")
+                    .font(.caption2)
+                    .foregroundStyle(AppColor.gold)
+                Text("Unlock deeper analysis")
+                    .font(.caption)
+                    .foregroundStyle(AppColor.secondaryText)
+                Spacer()
+                Text("Upgrade")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(AppColor.gold)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(AppColor.gold.opacity(0.12), in: Capsule())
+            }
+            .padding(.horizontal, AppSpacing.md)
+            .padding(.vertical, AppSpacing.sm)
+            .background(AppColor.gold.opacity(0.06), in: RoundedRectangle(cornerRadius: AppRadius.sm))
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showPaywall) {
+            ProUpgradeView()
+        }
+    }
+}
+```
+
+**Step 2: Add CTA gating to `GamePlayViewModel`**
+
+In `ChessCoach/ViewModels/GamePlayViewModel.swift`, add a property:
+```swift
+var hasShownUpgradeCTA = false
+```
+
+**Step 3: Show CTA in feed after first deviation (free tier only)**
+
+In `GamePlayViewModel+Session.swift`, in `showOffBookGuidance()`, after setting `userCoachingText`, add:
+
+```swift
+// Show upgrade CTA once per session for free-tier users
+if !hasShownUpgradeCTA {
+    hasShownUpgradeCTA = true
+    showUpgradeCTA = true  // New @Published var drives CTA visibility
+}
+```
+
+Add `@Published var showUpgradeCTA = false` to `GamePlayViewModel.swift` if needed — or handle via the feed entry system by appending a CTA-type feed entry. The exact wiring depends on how the feed renders. The simplest approach: add the CTA inline after the coaching text in the feed row, gated by `!hasShownUpgradeCTA && !hasLLM`.
+
+**Step 4: Build and verify**
+
+Run: `xcodegen generate && xcodebuild build -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -3`
+Expected: BUILD SUCCEEDED
+
+**Step 5: Commit**
+
+```bash
+git add ChessCoach/Components/Feed/CoachingUpgradeCTA.swift ChessCoach/ViewModels/GamePlayViewModel.swift ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+git commit -m "feat: add CoachingUpgradeCTA with once-per-session paywall prompt"
+```
+
+---
+
+### Task 5: Pass `DeviationCategory` to LLM context
+
+**Files:**
+- Modify: `ChessCoach/Services/LLMService/LLMTypes.swift:11-33` (add field to CoachingContext)
+- Modify: `ChessCoach/Services/CoachingService/CoachingService.swift:287-327` (pass category in buildContext)
+- Modify: `ChessCoach/Config/PromptCatalog.swift` (include category in prompt)
+- Modify: `ChessCoachTests/Services/LLMServiceTests.swift` (update test CoachingContext instantiations)
+
+**Step 1: Add `deviationCategory` to `CoachingContext`**
+
+In `LLMTypes.swift`, add after `bookStatus`:
+```swift
+let deviationCategory: DeviationCategory?
+```
+
+**Step 2: Update `buildContext()` in `CoachingService.swift`**
+
+Add `deviationCategory: DeviationCategory? = nil` parameter to `buildContext()` and pass it through to the `CoachingContext` initializer.
+
+**Step 3: Pass category from `freeCoaching()` and `getCoaching()`**
+
+In `freeCoaching()`, after calling `offBookService.generateGuidance()`, pass `guidance.category` when building the context (or store it for later use in prompt building).
+
+Actually, the simpler approach: in `getCoaching()`, when `bookStatus` indicates off-book and LLM is available, call `classifyDeviation()` and pass the result to `buildContext()`:
+
+```swift
+let deviationCategory: DeviationCategory?
+if let bs = bookStatus, case .onBook = bs {
+    deviationCategory = nil
+} else if bookStatus != nil {
+    deviationCategory = OffBookCoachingService.classifyDeviation(
+        fen: fen, moveHistory: [], playerIsWhite: studentColor == "White"
+    )
+} else {
+    deviationCategory = nil
+}
+```
+
+**Step 4: Update prompt template**
+
+In `PromptCatalog.swift`, in the opponent deviation prompt section, add context about the deviation category:
+
+```swift
+if let category = context.deviationCategory {
+    switch category {
+    case .tempoWaste:
+        guidance += " The opponent wasted a tempo by moving the same piece twice."
+    case .centerConcession:
+        guidance += " The opponent has conceded the center — no opponent pawns on d4/d5/e4/e5."
+    case .delayedDevelopment:
+        guidance += " The opponent is behind in development with multiple minor pieces still on the back rank."
+    case .delayedCastling:
+        guidance += " The opponent has not castled and their king may be vulnerable."
+    case .knownAlternative(let name):
+        guidance += " The opponent is playing the \(name)."
+    case .unclassified:
+        break
+    }
+}
+```
+
+**Step 5: Update test instantiations**
+
+In `LLMServiceTests.swift`, add `deviationCategory: nil` to all `CoachingContext` initializers.
+
+**Step 6: Build and test**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5`
+Expected: PASS
+
+**Step 7: Commit**
+
+```bash
+git add ChessCoach/Services/LLMService/LLMTypes.swift ChessCoach/Services/CoachingService/CoachingService.swift ChessCoach/Config/PromptCatalog.swift ChessCoachTests/Services/LLMServiceTests.swift
+git commit -m "feat: pass DeviationCategory to LLM prompt for targeted coaching"
+```
+
+---
+
+### Task 6: Final verification
+
+**Step 1: Full build**
+
+```bash
+xcodegen generate && xcodebuild build -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED
+
+**Step 2: Full test suite**
+
+```bash
+xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ChessCoachTests 2>&1 | tail -5
+```
+Expected: TEST SUCCEEDED
+
+**Step 3: Grep for removed patterns**
+
+```bash
+grep -r "left the.*at move" ChessCoach/
+grep -r "buildSummary" ChessCoach/
+```
+Expected: Zero results for both
+
+**Step 4: Verify new patterns exist**
+
+```bash
+grep -r "DeviationCategory" ChessCoach/ | wc -l
+grep -r "CoachingTierBadge" ChessCoach/ | wc -l
+grep -r "CoachingUpgradeCTA" ChessCoach/ | wc -l
+```
+Expected: Multiple results for each

--- a/docs/plans/2026-03-04-off-book-coaching-design.md
+++ b/docs/plans/2026-03-04-off-book-coaching-design.md
@@ -1,0 +1,105 @@
+# Phase 4: Off-Book Coaching + Opening Indicator — Design
+
+## Overview
+
+Three sub-features that make coaching useful beyond the opening book:
+
+1. **Opening Indicator** — persistent dual-side banner showing detected openings
+2. **OffBookCoachingService** — plan-based coaching when the game leaves book
+3. **Free-Tier Coaching Fix** — replace personality witticisms with factual opening data
+
+## 1. Opening Indicator
+
+### Component: `OpeningIndicatorBanner`
+
+Persistent view below the top bar in GamePlayView. Shows both sides' detected openings.
+
+**Layout**: `"You: Italian Game"` left-aligned, `"Opp: Two Knights"` right-aligned. Hidden until first detection, animates in.
+
+**Data flow**:
+- `GamePlayViewModel` holds `@Published var detection: HolisticDetection?`
+- After every move, call `holisticDetector.detect(moves:)` to update
+- HolisticDetector is cheap (tree lookup) — safe to call every move
+
+**Feed integration**:
+- New coaching entry type for opening detection events
+- Fired when: (a) first detection for either side, (b) primary detection changes
+- Example: "Your opponent switched to the Philidor Defense"
+
+## 2. OffBookCoachingService
+
+### Purpose
+
+When the game leaves book, generate coaching that references the opening's plan instead of generic "focus on development" text.
+
+### Interface
+
+```swift
+struct OffBookCoachingService: Sendable {
+    func generateGuidance(
+        fen: String,
+        opening: Opening,
+        bookStatus: BookStatus,
+        moveHistory: [String]
+    ) -> OffBookGuidance
+}
+
+struct OffBookGuidance: Sendable {
+    let summary: String          // "You left the Italian Game at move 7"
+    let planReminder: String     // "The plan is to target f7 with your bishop"
+    let suggestion: String?      // "Consider developing your bishop to c4"
+    let relevantGoals: [StrategicGoal]
+}
+```
+
+### How It Works (Free Tier)
+
+1. Check which `StrategicGoal`s are still achievable by parsing `checkCondition` against current FEN
+2. Identify unachieved `PieceTarget`s (piece not on ideal squares)
+3. Build template: "You left the book at move {ply}. The plan was: {summary}. From here, focus on: {unmet goal}. Consider developing your {piece} toward {squares}."
+4. For opponent deviations: "Your opponent deviated with {san}. The plan still works: {adapted advice}."
+
+### Goal Relevance Checking
+
+Simple FEN parsing for `checkCondition` strings like `"bishop_on_diagonal_a2g8"`, `"pawn_on_e4"`, `"castled_kingside"`. If nil or unparseable, assume relevant.
+
+### Paid Tier Enhancement
+
+Pass plan context + current FEN to CoachingService's existing LLM flow. The prompt already accepts plan data — add off-book context flag.
+
+### When Called
+
+- On transition to off-book: immediate guidance
+- Subsequent off-book moves: re-generate every ~3 moves to avoid spam
+- Results go into coaching feed as special entries
+
+## 3. Free-Tier Coaching Fix
+
+### Problem
+
+`fallbackCoaching()` returns personality witticisms + "The book move is X" which is often wrong or unhelpful.
+
+### Solution
+
+Replace `fallbackCoaching()` → `freeCoaching()` with factual data:
+
+**On-book**: Use `OpeningMove.explanation` directly — every move has a 1-2 sentence explanation.
+
+**Off-book**: Delegate to `OffBookCoachingService.generateGuidance()`.
+
+**Opponent moves**: Show opponent move's explanation if in tree, otherwise "Your opponent played {san}. Stay focused on {next plan goal}."
+
+**Personality**: Keep for session completion celebrations only. Remove from move-by-move coaching.
+
+### CoachingService Changes
+
+- Rename `fallbackCoaching()` → `freeCoaching()`
+- Add `Opening` object to `CoachingContext` (currently only has `openingName`)
+- `freeCoaching()` reads from `OpeningMove.explanation` (on-book) or `OffBookCoachingService` (off-book)
+
+## Architecture Decisions
+
+- **Standalone OffBookCoachingService** (not inline in CoachingService) for clean separation and testability
+- **HolisticDetector called every move** — cheap tree lookup, acceptable cost
+- **Template-only free tier** — no Stockfish dependency for free off-book coaching
+- **Opening indicator: banner + feed entries** — persistent banner for current state, feed entries for changes

--- a/docs/plans/2026-03-04-off-book-coaching-plan.md
+++ b/docs/plans/2026-03-04-off-book-coaching-plan.md
@@ -1,0 +1,833 @@
+# Phase 4: Off-Book Coaching + Opening Indicator — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make coaching useful beyond the opening book — show detected openings for both sides, generate plan-based coaching when the game goes off-book, and replace personality witticisms with factual opening data on the free tier.
+
+**Architecture:** New `OffBookCoachingService` generates plan-based guidance from `OpeningPlan.strategicGoals` and `pieceTargets`. `HolisticDetector` (already exists) runs after every move to feed a persistent `OpeningIndicatorBanner`. `CoachingService.fallbackCoaching()` is replaced with `freeCoaching()` that uses `OpeningMove.explanation` on-book and `OffBookCoachingService` off-book.
+
+**Tech Stack:** SwiftUI, Swift 6 strict concurrency, Swift Testing framework, XcodeGen
+
+---
+
+### Task 1: OffBookGuidance Model
+
+**Files:**
+- Create: `ChessCoach/Services/OffBookCoachingService.swift`
+- Test: `ChessCoachTests/Services/OffBookCoachingServiceTests.swift`
+
+**Step 1: Write the test file**
+
+```swift
+import Testing
+import Foundation
+@testable import ChessCoach
+
+@Suite(.serialized)
+struct OffBookCoachingServiceTests {
+    let italian: Opening = OpeningDatabase.shared.openings.first { $0.id == "italian" }!
+
+    @Test func guidanceIncludesPlanSummary() {
+        let service = OffBookCoachingService()
+        let guidance = service.generateGuidance(
+            fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+            opening: italian,
+            deviationPly: 4,
+            moveHistory: ["e2e4", "e7e5", "g1f3", "b8c6"]
+        )
+        #expect(guidance.summary.contains("move"))
+        #expect(!guidance.planReminder.isEmpty)
+        #expect(!guidance.relevantGoals.isEmpty)
+    }
+
+    @Test func guidanceForOpponentDeviation() {
+        let service = OffBookCoachingService()
+        let guidance = service.generateGuidance(
+            fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+            opening: italian,
+            deviationPly: 5,
+            moveHistory: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4"],
+            opponentDeviation: (played: "d7d6", expected: "Bc5")
+        )
+        #expect(guidance.summary.contains("opponent") || guidance.summary.contains("Opponent"))
+    }
+
+    @Test func relevantGoalsFiltersByCheckCondition() {
+        let service = OffBookCoachingService()
+        // FEN where bishop IS on a2-g8 diagonal (c4)
+        let fenWithBishop = "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 0 3"
+        let guidance = service.generateGuidance(
+            fen: fenWithBishop,
+            opening: italian,
+            deviationPly: 6,
+            moveHistory: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4", "g8f6"]
+        )
+        // Should still have goals (some achieved, some not)
+        #expect(!guidance.relevantGoals.isEmpty)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' -only-testing:ChessCoachTests/OffBookCoachingServiceTests 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED|error:'`
+Expected: FAIL — `OffBookCoachingService` not found
+
+**Step 3: Write the OffBookCoachingService**
+
+Create `ChessCoach/Services/OffBookCoachingService.swift`:
+
+```swift
+import Foundation
+
+struct OffBookGuidance: Sendable {
+    let summary: String
+    let planReminder: String
+    let suggestion: String?
+    let relevantGoals: [StrategicGoal]
+}
+
+struct OffBookCoachingService: Sendable {
+
+    func generateGuidance(
+        fen: String,
+        opening: Opening,
+        deviationPly: Int,
+        moveHistory: [String],
+        opponentDeviation: (played: String, expected: String)? = nil
+    ) -> OffBookGuidance {
+        guard let plan = opening.plan else {
+            return OffBookGuidance(
+                summary: "You left the book at move \(deviationPly / 2 + 1).",
+                planReminder: "Keep developing your pieces and controlling the center.",
+                suggestion: nil,
+                relevantGoals: []
+            )
+        }
+
+        let moveNumber = deviationPly / 2 + 1
+        let relevant = relevantGoals(from: plan, fen: fen)
+        let unmet = unmetPieceTargets(from: plan, fen: fen)
+
+        // Summary
+        let summary: String
+        if let dev = opponentDeviation {
+            summary = "Your opponent deviated at move \(moveNumber) with \(dev.played) (expected \(dev.expected))."
+        } else {
+            summary = "You left the \(opening.name) at move \(moveNumber)."
+        }
+
+        // Plan reminder
+        let planReminder = plan.summary
+
+        // Suggestion from unmet targets or top relevant goal
+        let suggestion: String?
+        if let target = unmet.first {
+            let squares = target.idealSquares.joined(separator: " or ")
+            suggestion = "Consider developing your \(target.piece) toward \(squares) — \(target.reasoning.lowercased())"
+        } else if let goal = relevant.first {
+            suggestion = "Focus on: \(goal.description.lowercased())"
+        } else {
+            suggestion = nil
+        }
+
+        return OffBookGuidance(
+            summary: summary,
+            planReminder: planReminder,
+            suggestion: suggestion,
+            relevantGoals: relevant
+        )
+    }
+
+    // MARK: - Goal Relevance
+
+    func relevantGoals(from plan: OpeningPlan, fen: String) -> [StrategicGoal] {
+        plan.strategicGoals.filter { goal in
+            guard let condition = goal.checkCondition else { return true }
+            return !isConditionMet(condition, in: fen)
+        }
+        .sorted { ($0.priority) < ($1.priority) }
+    }
+
+    func isConditionMet(_ condition: String, in fen: String) -> Bool {
+        let boardPart = String(fen.prefix(while: { $0 != " " }))
+
+        if condition.hasPrefix("bishop_on_diagonal_") {
+            let diagonal = String(condition.dropFirst("bishop_on_diagonal_".count))
+            return isBishopOnDiagonal(diagonal, board: boardPart)
+        }
+        if condition.hasPrefix("pawn_on_") {
+            let square = String(condition.dropFirst("pawn_on_".count))
+            return isPieceOnSquare("P", square: square, board: boardPart)
+        }
+        if condition == "castled_kingside" {
+            return isCastled(kingside: true, fen: fen)
+        }
+        if condition == "castled_queenside" {
+            return isCastled(kingside: false, fen: fen)
+        }
+        // Unknown condition — assume not met (goal still relevant)
+        return false
+    }
+
+    // MARK: - Piece Target Checking
+
+    func unmetPieceTargets(from plan: OpeningPlan, fen: String) -> [PieceTarget] {
+        let boardPart = String(fen.prefix(while: { $0 != " " }))
+        let isWhite = fen.contains(" w ")
+
+        return plan.pieceTargets.filter { target in
+            let pieceLetter = pieceChar(for: target.piece, isWhite: isWhite)
+            guard let piece = pieceLetter else { return false }
+            return !target.idealSquares.contains(where: { isPieceOnSquare(piece, square: $0, board: boardPart) })
+        }
+    }
+
+    // MARK: - FEN Helpers
+
+    private func pieceChar(for name: String, isWhite: Bool) -> String? {
+        let lower = name.lowercased()
+        let base: String?
+        if lower.contains("bishop") { base = "B" }
+        else if lower.contains("knight") { base = "N" }
+        else if lower.contains("rook") { base = "R" }
+        else if lower.contains("queen") { base = "Q" }
+        else if lower.contains("king") { base = "K" }
+        else if lower.contains("pawn") { base = "P" }
+        else { base = nil }
+        guard let b = base else { return nil }
+        return isWhite ? b : b.lowercased()
+    }
+
+    private func isPieceOnSquare(_ piece: String, square: String, board: String) -> Bool {
+        guard square.count == 2,
+              let file = square.first?.asciiValue.map({ Int($0) - Int(Character("a").asciiValue!) }),
+              let rank = square.last?.wholeNumberValue,
+              (0..<8).contains(file), (1...8).contains(rank) else { return false }
+
+        let rows = board.split(separator: "/")
+        guard rows.count == 8 else { return false }
+        let rowIndex = 8 - rank
+        let row = String(rows[rowIndex])
+
+        var col = 0
+        for ch in row {
+            if col == file { return String(ch) == piece }
+            if ch.isNumber { col += ch.wholeNumberValue ?? 0 }
+            else { col += 1 }
+        }
+        return false
+    }
+
+    private func isBishopOnDiagonal(_ diagonal: String, board: String) -> Bool {
+        // Parse diagonal like "a2g8" — check all squares on that diagonal for a bishop
+        guard diagonal.count == 4 else { return false }
+        let startFile = Int(diagonal.first!.asciiValue!) - Int(Character("a").asciiValue!)
+        let startRank = Int(String(diagonal[diagonal.index(diagonal.startIndex, offsetBy: 1)]))! - 1
+        let endFile = Int(diagonal[diagonal.index(diagonal.startIndex, offsetBy: 2)].asciiValue!) - Int(Character("a").asciiValue!)
+        let endRank = Int(String(diagonal.last!))! - 1
+
+        let fileDelta = endFile > startFile ? 1 : -1
+        let rankDelta = endRank > startRank ? 1 : -1
+
+        var f = startFile, r = startRank
+        while f >= 0 && f < 8 && r >= 0 && r < 8 {
+            let square = "\(Character(UnicodeScalar(f + Int(Character("a").asciiValue!))!))\(r + 1)"
+            if isPieceOnSquare("B", square: square, board: board) || isPieceOnSquare("b", square: square, board: board) {
+                return true
+            }
+            f += fileDelta
+            r += rankDelta
+            if f == endFile + fileDelta { break }
+        }
+        return false
+    }
+
+    private func isCastled(kingside: Bool, fen: String) -> Bool {
+        let parts = fen.split(separator: " ")
+        guard parts.count >= 3 else { return false }
+        let castling = String(parts[2])
+        // If castling rights are gone, king has likely moved (proxy for castled)
+        let isWhite = String(parts[1]) == "w" || String(parts[1]) == "b" // check both sides
+        if kingside {
+            return !castling.contains("K") && !castling.contains("k")
+        } else {
+            return !castling.contains("Q") && !castling.contains("q")
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' -only-testing:ChessCoachTests/OffBookCoachingServiceTests 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED|error:'`
+Expected: TEST SUCCEEDED
+
+**Step 5: Commit**
+
+```bash
+git add ChessCoach/Services/OffBookCoachingService.swift ChessCoachTests/Services/OffBookCoachingServiceTests.swift
+git commit -m "Add OffBookCoachingService with plan-based guidance generation"
+```
+
+---
+
+### Task 2: Opening Indicator Banner
+
+**Files:**
+- Create: `ChessCoach/Components/Bars/OpeningIndicatorBanner.swift`
+- Modify: `ChessCoach/Views/GamePlay/GamePlayView+TopBar.swift:126-132` (statusBanners)
+- Modify: `ChessCoach/ViewModels/GamePlayViewModel.swift` (add detection tracking)
+- Test: `ChessCoachTests/Views/OpeningIndicatorBannerTests.swift`
+
+**Step 1: Write the test**
+
+```swift
+import Testing
+import Foundation
+@testable import ChessCoach
+
+@Suite
+struct OpeningIndicatorBannerTests {
+    @Test func detectsItalianAfterMoves() {
+        let detector = HolisticDetector()
+        let detection = detector.detect(moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4"])
+        #expect(detection.whiteFramework.primary != nil)
+        let name = detection.whiteFramework.primary?.opening.name ?? ""
+        #expect(name.lowercased().contains("italian"))
+    }
+
+    @Test func bothSidesDetected() {
+        let detector = HolisticDetector()
+        let detection = detector.detect(moves: ["e2e4", "e7e5", "g1f3", "b8c6", "f1c4", "f8c5"])
+        #expect(detection.whiteFramework.primary != nil)
+        #expect(detection.blackFramework.primary != nil)
+    }
+
+    @Test func emptyMovesReturnsNoDetection() {
+        let detector = HolisticDetector()
+        let detection = detector.detect(moves: [])
+        // May or may not have primary — depends on database. Just verify no crash.
+        _ = detection.whiteFramework
+        _ = detection.blackFramework
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' -only-testing:ChessCoachTests/OpeningIndicatorBannerTests 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED|error:'`
+Expected: FAIL (file not found)
+
+**Step 3: Create the banner component**
+
+Create `ChessCoach/Components/Bars/OpeningIndicatorBanner.swift`:
+
+```swift
+import SwiftUI
+
+struct OpeningIndicatorBanner: View {
+    let whiteOpening: String?
+    let blackOpening: String?
+    let playerColor: PieceColor
+
+    var body: some View {
+        if whiteOpening != nil || blackOpening != nil {
+            HStack(spacing: 0) {
+                sideLabel(
+                    label: playerColor == .white ? "You" : "Opp",
+                    opening: whiteOpening,
+                    color: .white
+                )
+
+                Spacer(minLength: 4)
+
+                Rectangle()
+                    .fill(AppColor.tertiaryText.opacity(0.3))
+                    .frame(width: 1, height: 14)
+
+                Spacer(minLength: 4)
+
+                sideLabel(
+                    label: playerColor == .black ? "You" : "Opp",
+                    opening: blackOpening,
+                    color: Color(white: 0.3)
+                )
+            }
+            .padding(.horizontal, AppSpacing.screenPadding)
+            .padding(.vertical, AppSpacing.xxs)
+            .background(AppColor.elevatedBackground.opacity(0.6))
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    private func sideLabel(label: String, opening: String?, color: Color) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+                .overlay(Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 0.5))
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(AppColor.tertiaryText)
+            Text(opening ?? "—")
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(AppColor.secondaryText)
+                .lineLimit(1)
+        }
+    }
+}
+```
+
+**Step 4: Wire detection into GamePlayViewModel**
+
+Modify `ChessCoach/ViewModels/GamePlayViewModel.swift`:
+
+At the property declarations (around line 78), the `holisticDetection` property already exists:
+```swift
+var holisticDetection: HolisticDetection = .none
+```
+
+Add a method to update detection after each move. Add near the bottom of the file, before the closing brace:
+
+```swift
+// MARK: - Opening Detection
+
+func updateOpeningDetection() {
+    let moves = gameState.moveHistory.map { $0.from + $0.to }
+    let newDetection = holisticDetector.detect(moves: moves)
+    let oldWhite = holisticDetection.whiteFramework.primary?.opening.name
+    let oldBlack = holisticDetection.blackFramework.primary?.opening.name
+    holisticDetection = newDetection
+    let newWhite = newDetection.whiteFramework.primary?.opening.name
+    let newBlack = newDetection.blackFramework.primary?.opening.name
+
+    // Feed entry on first detection or change
+    if let name = newWhite, name != oldWhite {
+        appendDetectionFeedEntry(side: "White", name: name)
+    }
+    if let name = newBlack, name != oldBlack {
+        appendDetectionFeedEntry(side: "Black", name: name)
+    }
+}
+
+private func appendDetectionFeedEntry(side: String, name: String) {
+    let ply = gameState.plyCount
+    appendToFeed(
+        ply: ply,
+        san: nil,
+        coaching: "\(side) is playing the \(name).",
+        isDeviation: false,
+        fen: gameState.fen
+    )
+}
+```
+
+**Step 5: Call updateOpeningDetection() after each move**
+
+In `GamePlayViewModel+Session.swift`, at the end of `sessionUserMoved()` (the user-move handler) and at the end of opponent move handling, add:
+
+After user move is processed (around line 130, after `appendToFeed` for user move):
+```swift
+updateOpeningDetection()
+```
+
+After opponent move is processed (around line 400, after opponent's `appendToFeed`):
+```swift
+updateOpeningDetection()
+```
+
+Also call it in trainer mode moves if the viewModel handles trainer mode in a different extension — check and add similarly.
+
+**Step 6: Add banner to statusBanners in GamePlayView+TopBar.swift**
+
+Replace the `statusBanners` computed property (lines 126-132):
+
+```swift
+@ViewBuilder
+var statusBanners: some View {
+    if viewModel.mode.isSession {
+        if viewModel.isModelLoading {
+            coachLoadingBar
+        }
+    }
+
+    OpeningIndicatorBanner(
+        whiteOpening: viewModel.holisticDetection.whiteFramework.primary?.opening.name,
+        blackOpening: viewModel.holisticDetection.blackFramework.primary?.opening.name,
+        playerColor: viewModel.mode.playerColor
+    )
+}
+```
+
+**Step 7: Run tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED'`
+Expected: TEST SUCCEEDED
+
+**Step 8: Commit**
+
+```bash
+git add ChessCoach/Components/Bars/OpeningIndicatorBanner.swift ChessCoachTests/Views/OpeningIndicatorBannerTests.swift ChessCoach/ViewModels/GamePlayViewModel.swift ChessCoach/ViewModels/GamePlayViewModel+Session.swift ChessCoach/Views/GamePlay/GamePlayView+TopBar.swift
+git commit -m "Add dual-side opening indicator banner with feed detection entries"
+```
+
+---
+
+### Task 3: Wire OffBookCoachingService into Session
+
+**Files:**
+- Modify: `ChessCoach/ViewModels/GamePlayViewModel.swift` (add offBookService property)
+- Modify: `ChessCoach/ViewModels/GamePlayViewModel+Session.swift:654-667` (replace showOffBookGuidance)
+- Test: Existing tests + manual verification
+
+**Step 1: Add service to ViewModel**
+
+In `GamePlayViewModel.swift`, add property near line 84 (alongside holisticDetector):
+
+```swift
+let offBookCoachingService = OffBookCoachingService()
+```
+
+Also add a counter to throttle off-book guidance:
+
+```swift
+var offBookGuidanceLastPly: Int = -10
+```
+
+**Step 2: Replace showOffBookGuidance()**
+
+In `GamePlayViewModel+Session.swift`, replace lines 654-667:
+
+```swift
+func showOffBookGuidance() {
+    guard isUserTurn, !sessionComplete else { return }
+    guard let opening = mode.opening else {
+        userCoachingText = "You're on your own. Focus on developing pieces and keeping your king safe."
+        return
+    }
+
+    // Throttle: only generate new guidance every 3 plies
+    let currentPly = gameState.plyCount
+    guard currentPly - offBookGuidanceLastPly >= 3 || offBookGuidanceLastPly < 0 else {
+        // Still show arrow hint if available
+        showOffBookArrowHint()
+        return
+    }
+    offBookGuidanceLastPly = currentPly
+
+    let deviationPly: Int
+    switch bookStatus {
+    case .userDeviated(_, let atPly): deviationPly = atPly
+    case .opponentDeviated(_, _, let atPly): deviationPly = atPly
+    case .offBook(let since): deviationPly = since
+    default: deviationPly = currentPly
+    }
+
+    var opponentDev: (played: String, expected: String)?
+    if case .opponentDeviated(let expected, let playedSAN, _) = bookStatus {
+        opponentDev = (played: playedSAN, expected: expected.san)
+    }
+
+    let guidance = offBookCoachingService.generateGuidance(
+        fen: gameState.fen,
+        opening: opening,
+        deviationPly: deviationPly,
+        moveHistory: gameState.moveHistory.map { $0.from + $0.to },
+        opponentDeviation: opponentDev
+    )
+
+    var text = guidance.summary
+    if !guidance.planReminder.isEmpty {
+        text += " \(guidance.planReminder)"
+    }
+    if let suggestion = guidance.suggestion {
+        text += " \(suggestion)"
+    }
+    userCoachingText = text
+
+    showOffBookArrowHint()
+}
+
+private func showOffBookArrowHint() {
+    if mode.showsArrows, let hint = bestResponseHint, hint.count >= 4 {
+        arrowFrom = String(hint.prefix(2))
+        arrowTo = String(hint.dropFirst(2).prefix(2))
+    }
+}
+```
+
+Also add `offBookGuidanceLastPly = -10` in `restartSession()` (around line 710 area, alongside other resets).
+
+**Step 3: Run all tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED'`
+Expected: TEST SUCCEEDED
+
+**Step 4: Commit**
+
+```bash
+git add ChessCoach/ViewModels/GamePlayViewModel.swift ChessCoach/ViewModels/GamePlayViewModel+Session.swift
+git commit -m "Wire OffBookCoachingService into session — plan-based off-book guidance"
+```
+
+---
+
+### Task 4: Free-Tier Coaching Fix
+
+**Files:**
+- Modify: `ChessCoach/Services/CoachingService/CoachingService.swift:317-345` (replace fallbackCoaching)
+- Modify: `ChessCoach/Services/LLMService/LLMTypes.swift` (add fields to CoachingContext)
+- Test: `ChessCoachTests/Services/CoachingServiceTests.swift`
+
+**Step 1: Add fields to CoachingContext**
+
+In `LLMTypes.swift`, add to the `CoachingContext` struct (after `coachPersonalityPrompt`):
+
+```swift
+let opening: Opening?
+let bookStatus: BookStatus?
+```
+
+**Step 2: Update buildContext() in CoachingService**
+
+In `CoachingService.swift`, find the `buildContext()` method and add the new fields. The method constructs a `CoachingContext` — add `opening: curriculumService.opening` and `bookStatus: nil` (we'll pass it through later).
+
+Also add `bookStatus` parameter to `getCoaching()` signature:
+
+```swift
+func getCoaching(
+    fen: String,
+    lastMove: String,
+    scoreBefore: Int,
+    scoreAfter: Int,
+    ply: Int,
+    userELO: Int,
+    moveHistory: String = "",
+    isUserMove: Bool = true,
+    studentColor: String? = nil,
+    matchedResponseName: String? = nil,
+    matchedResponseAdjustment: String? = nil,
+    bookStatus: BookStatus? = nil  // NEW
+) async -> String?
+```
+
+And pass it through to `buildContext()` → `CoachingContext`.
+
+**Step 3: Replace fallbackCoaching with freeCoaching**
+
+Replace the `fallbackCoaching(for:)` method (lines 317-345) with:
+
+```swift
+private func freeCoaching(for context: CoachingContext) -> String? {
+    // Off-book: delegate to plan-based guidance
+    if let bookStatus = context.bookStatus, let opening = context.opening {
+        switch bookStatus {
+        case .offBook, .userDeviated, .opponentDeviated:
+            let service = OffBookCoachingService()
+            let deviationPly: Int
+            switch bookStatus {
+            case .userDeviated(_, let p): deviationPly = p
+            case .opponentDeviated(_, _, let p): deviationPly = p
+            case .offBook(let p): deviationPly = p
+            default: deviationPly = context.plyNumber
+            }
+            let guidance = service.generateGuidance(
+                fen: context.fen,
+                opening: opening,
+                deviationPly: deviationPly,
+                moveHistory: []
+            )
+            return "\(guidance.summary) \(guidance.planReminder)"
+        case .onBook:
+            break
+        }
+    }
+
+    // On-book: use opening move explanations
+    if context.isUserMove {
+        if let explanation = context.expectedMoveExplanation, !explanation.isEmpty {
+            switch context.moveCategory {
+            case .goodMove:
+                return explanation
+            case .okayMove:
+                let expected = context.expectedMoveSAN ?? "the book move"
+                return "The book move is \(expected). \(explanation)"
+            case .mistake:
+                let expected = context.expectedMoveSAN ?? "the book move"
+                return "The recommended move is \(expected). \(explanation)"
+            default:
+                return nil
+            }
+        }
+        // Fallback if no explanation available
+        switch context.moveCategory {
+        case .goodMove: return "Good — that's the book move."
+        case .okayMove:
+            let expected = context.expectedMoveSAN ?? "the book move"
+            return "The book move is \(expected)."
+        case .mistake:
+            let expected = context.expectedMoveSAN ?? "the book move"
+            return "The recommended move is \(expected)."
+        default: return nil
+        }
+    } else {
+        // Opponent moves
+        if context.moveCategory == .deviation {
+            if let name = context.matchedResponseName, let adj = context.matchedResponseAdjustment {
+                return "Your opponent played the \(name). \(adj)"
+            }
+            return "Your opponent deviated from the main line."
+        }
+        return nil  // Don't generate coaching for every opponent move on free tier
+    }
+}
+```
+
+Update the call site in `getCoaching()` — replace `fallbackCoaching(for: context)` with `freeCoaching(for: context)`.
+
+**Step 4: Update test**
+
+In `ChessCoachTests/Services/CoachingServiceTests.swift`, update or add a test for free-tier coaching:
+
+```swift
+@Test func freeCoachingUsesExplanation() async {
+    let llm = MockLLMService()
+    let curriculum = CurriculumService(opening: italian, familiarity: 0.1)
+    let coaching = CoachingService(llmService: llm, curriculumService: curriculum, featureAccess: LockedAccess())
+    let result = await coaching.getCoaching(
+        fen: "startpos",
+        lastMove: "e2e4",
+        scoreBefore: 0,
+        scoreAfter: 0,
+        ply: 0,
+        userELO: 800,
+        isUserMove: true
+    )
+    // Should return something factual, not a personality witticism
+    #expect(result != nil)
+    // Should not contain personality patterns
+    if let text = result {
+        #expect(!text.contains("🎭"))
+    }
+}
+```
+
+**Step 5: Run all tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED'`
+Expected: TEST SUCCEEDED
+
+**Step 6: Commit**
+
+```bash
+git add ChessCoach/Services/CoachingService/CoachingService.swift ChessCoach/Services/LLMService/LLMTypes.swift ChessCoachTests/Services/CoachingServiceTests.swift
+git commit -m "Replace fallbackCoaching with freeCoaching — factual data from opening files"
+```
+
+---
+
+### Task 5: Pass BookStatus Through to CoachingService
+
+**Files:**
+- Modify: `ChessCoach/ViewModels/GamePlayViewModel+Session.swift` (pass bookStatus to getCoaching/getBatchedCoaching)
+
+**Step 1: Update generateCoaching() calls**
+
+In `GamePlayViewModel+Session.swift`, find `generateCoaching()` (around line 820) and add `bookStatus: bookStatus` parameter to the `coachingService.getCoaching()` call.
+
+Find all calls to `coachingService.getCoaching()` and `coachingService.getBatchedCoaching()` in the session extension and add the `bookStatus` parameter.
+
+**Step 2: Update getBatchedCoaching in CoachingService**
+
+In `CoachingService.swift`, add `bookStatus` parameter to `getBatchedCoaching()` method signature as well, and pass through to context building.
+
+**Step 3: Run all tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED'`
+Expected: TEST SUCCEEDED
+
+**Step 4: Commit**
+
+```bash
+git add ChessCoach/ViewModels/GamePlayViewModel+Session.swift ChessCoach/Services/CoachingService/CoachingService.swift
+git commit -m "Thread bookStatus through to CoachingService for off-book free-tier coaching"
+```
+
+---
+
+### Task 6: Wire Detection into Trainer Mode
+
+**Files:**
+- Modify: `ChessCoach/ViewModels/GamePlayViewModel.swift` (call updateOpeningDetection from trainer flow)
+
+**Step 1: Find trainer move handling**
+
+Check `GamePlayViewModel.swift` or a trainer extension for where moves are processed in trainer mode. Add `updateOpeningDetection()` after each move in trainer flow (both user and bot moves).
+
+**Step 2: Run all tests**
+
+Run: `xcodegen generate && xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED'`
+Expected: TEST SUCCEEDED
+
+**Step 3: Commit**
+
+```bash
+git add ChessCoach/ViewModels/GamePlayViewModel.swift
+git commit -m "Wire opening detection into trainer mode"
+```
+
+---
+
+### Task 7: Final Verification and Cleanup
+
+**Step 1: Build clean**
+
+```bash
+xcodegen generate && xcodebuild build -scheme ChessCoach -destination 'generic/platform=iOS Simulator' -quiet 2>&1 | tail -5
+```
+
+**Step 2: Run all tests**
+
+```bash
+xcodebuild test -scheme ChessCoach -destination 'platform=iOS Simulator,id=7B2E26B7-1353-4D20-B2AA-479BB6729BD6' 2>&1 | /usr/bin/grep -E 'TEST SUCCEEDED|TEST FAILED'
+```
+
+**Step 3: Verify no dead code**
+
+```bash
+# Verify fallbackCoaching is gone
+grep -r "fallbackCoaching" ChessCoach/
+# Should return nothing
+```
+
+**Step 4: Commit any cleanup**
+
+```bash
+git add -A && git commit -m "Phase 4 cleanup: final verification"
+```
+
+---
+
+## Sequencing
+
+```
+Task 1 (OffBookCoachingService) ─── additive, new service + tests
+Task 2 (Opening Indicator)      ─── additive, new component + wiring
+Task 3 (Wire into Session)      ─── depends on Task 1
+Task 4 (Free-Tier Fix)          ─── depends on Task 1
+Task 5 (Thread BookStatus)      ─── depends on Task 4
+Task 6 (Trainer Detection)      ─── depends on Task 2
+Task 7 (Final Verification)     ─── depends on all
+```
+
+## Verification Checklist
+
+1. Opening indicator shows both sides' openings during play
+2. Feed entries appear when openings are first detected
+3. Off-book coaching references the opening plan, not generic advice
+4. Free tier shows `OpeningMove.explanation` for on-book moves
+5. Free tier shows plan-based guidance for off-book moves
+6. No personality witticisms in move-by-move coaching
+7. Trainer mode shows opening indicator
+8. All tests pass


### PR DESCRIPTION
## Summary

- **Opening Indicator Banner** — persistent dual-side banner below top bar showing detected openings for both sides ("You: Italian Game | Opp: Two Knights Defense"), with feed entries on first detection or change
- **OffBookCoachingService** — new service that generates plan-based coaching when the game leaves book, using `OpeningPlan.strategicGoals` and `pieceTargets` with FEN parsing to check goal relevance
- **Free-tier coaching fix** — replaced `fallbackCoaching()` personality witticisms with factual data from `OpeningMove.explanation` (on-book) and `OffBookCoachingService` (off-book)
- **BookStatus threading** — `CoachingService` now receives `bookStatus` + `opening` context so free-tier can detect off-book state

## Test plan

- [x] Build succeeds (warnings only)
- [x] All unit tests pass (TEST SUCCEEDED)
- [x] `fallbackCoaching` has zero references (grep clean)
- [ ] Manual: Opening indicator shows during guided/unguided/practice/trainer modes
- [ ] Manual: Off-book coaching shows plan-based guidance instead of "focus on development"
- [ ] Manual: Free-tier coaching shows move explanations, not personality witticisms


🤖 Generated with [Claude Code](https://claude.com/claude-code)